### PR TITLE
Update the library to work with Agda 2.6.4

### DIFF
--- a/CountablePowerSet.agda
+++ b/CountablePowerSet.agda
@@ -7,7 +7,7 @@ open import Cubical.Data.Empty as Empty
 open import Cubical.Data.Nat
 open import Cubical.Data.Sigma
 open import Cubical.Data.List as List
-open import Cubical.Data.Sum hiding (inl; inr) 
+open import Cubical.Data.Sum as ⊎ hiding (inl; inr)
 open import Cubical.Foundations.Everything hiding (assoc)
 open import Cubical.Functions.Logic as Logic
 open import Cubical.HITs.PropositionalTruncation as PT 
@@ -181,7 +181,7 @@ x ∈ trunc xs ys p q i j = isSetHProp (x ∈ xs) (x ∈ ys) (cong (x ∈_) p) (
 ∪-in-L = inl
 
 ∪-out : ∀ {A : Set} {P : P∞ A} {P' s} → ⟨ s ∈ (P ∪ P') ⟩ → ∥ ⟨ s ∈ P ⟩ ⊎ ⟨ s ∈ P' ⟩ ∥₁
-∪-out = PT.map (map-⊎ (λ x → x) snd)
+∪-out = PT.map (⊎.map (λ x → x) snd)
 
 ∪-in-R : ∀ {A : Set} {P : P∞ A} {P' s} → ⟨ s ∈ P' ⟩ → ⟨ s ∈ (P ∪ P') ⟩
 ∪-in-R s = inr (0 , s)

--- a/README.md
+++ b/README.md
@@ -14,4 +14,4 @@ Cubical Agda.
 
 The file [Main.agda](https://github.com/niccoloveltri/guarded-ccs-pi/blob/main/Main.agda) imports the whole development.
 
-The code typechecks using Agda version 2.6.2. It requires the installation of the [cubical](https://github.com/agda/cubical) library.
+The code typechecks using Agda version 2.6.4. It requires the installation of the [cubical](https://github.com/agda/cubical) library.

--- a/ccs/semantics/Algebra.agda
+++ b/ccs/semantics/Algebra.agda
@@ -99,7 +99,7 @@ mapProc'-eq' n m f p i = mapProc'-eq i n m f p
 mapProc-id : ∀ m Q → mapProc m m (\ x → x) Q ≡ Q
 mapProc-id = fix \ ih m Q → cong Fold (
   mapProc'-eq' _ _ _ _
-  ∙ cong′ (λ x → mapP∞ x (Unfold Q)) (funExt (λ { aQ' →
+  ∙ congS (λ x → mapP∞ x (Unfold Q)) (funExt (λ { aQ' →
       StepPath (mapAct-id _) (later-ext (λ α → ih α _ (theX aQ' α))) }))
   ∙ mapidP∞ (Unfold Q))
 
@@ -111,7 +111,7 @@ mapmapProc = fix \ where
     ∙ cong Fold
       (mapProc'-eq' _ _ _ _
        ∙ mapmapP∞ _ _ (Unfold p)
-       ∙ cong′ (λ x → mapP∞ x (Unfold p)) (funExt (λ { aQ' →
+       ∙ congS (λ x → mapP∞ x (Unfold p)) (funExt (λ { aQ' →
            StepPath (mapmapAct _) (later-ext (λ α → ih α _ _ _ _ _ (theX aQ' α)))})))
     ∙ sym (cong Fold (mapProc'-eq' _ _ _ _))
 
@@ -339,8 +339,8 @@ module _ where
   !Proc-eq : ∀ {n} {P : Proc n}
     → !Proc P ≡ Fold (stepL (Unfold P) (!Proc P) ∪ stepL (synchF (Unfold P) (Unfold P)) (!Proc P))
   !Proc-eq {n} {P} =
-    cong′ (λ x → isCCS-alg.!X (x n) P) (fix-eq ProcCCS-algF) ∙ cong Fold (fix-eq d) ∙ cong Fold (cong₂ _∪_ (cong (stepL (Unfold P))
-          (sym (cong′ (λ x → isCCS-alg.!X (x n) P) (fix-eq ProcCCS-algF))))
-          (cong (stepL (synchF (Unfold P) (Unfold P))) (sym (cong′ (λ x → isCCS-alg.!X (x n) P) (fix-eq ProcCCS-algF)))))
+    congS (λ x → isCCS-alg.!X (x n) P) (fix-eq ProcCCS-algF) ∙ cong Fold (fix-eq d) ∙ cong Fold (cong₂ _∪_ (cong (stepL (Unfold P))
+          (sym (congS (λ x → isCCS-alg.!X (x n) P) (fix-eq ProcCCS-algF))))
+          (cong (stepL (synchF (Unfold P) (Unfold P))) (sym (congS (λ x → isCCS-alg.!X (x n) P) (fix-eq ProcCCS-algF)))))
     where
       d = λ !p → stepL' (Unfold P ∪ synchF (Unfold P) (Unfold P)) (λ α → Fold (!p α))

--- a/ccs/semantics/Coalgebra.agda
+++ b/ccs/semantics/Coalgebra.agda
@@ -366,7 +366,7 @@ module _ (ih : ▹ ∀ {n} (P : CCS n) → Eval.eval _ P ≡  evalG P) where
      mapP∞ (λ x → x .theLabel , λ α → eval n (x .theX α)) (SL.stepL' (step P) Q) 
      ≡
      SL'.stepL' (Unfold (eval n P)) (\ α → eval n (Q α))
-  stepL'-step {n} P Q = stepL'-step-g (step P) Q ∙ (cong′ SL'.stepL' (sym (cong Unfold (fix-eq eval-fun <* n <* P))) <* (λ α → eval n (Q α)))
+  stepL'-step {n} P Q = stepL'-step-g (step P) Q ∙ (congS SL'.stepL' (sym (cong Unfold (fix-eq eval-fun <* n <* P))) <* (λ α → eval n (Q α)))
 
   nu-par : ∀ {n} P Q → eval-fun (next (fix eval-fun)) n (P ∣∣ Q) ≡ Fold (SL'.par (eval n P) (Unfold (eval n P))
                                                                                                                               (eval n Q) (Unfold (eval n Q)))
@@ -381,7 +381,7 @@ module _ (ih : ▹ ∀ {n} (P : CCS n) → Eval.eval _ P ≡  evalG P) where
   evalG-eq' end = refl
   evalG-eq' {n} (a · P) =
     ((fix-eq eval-fun <* n) <* (a · P)) 
-     ∙ sym (cong isCCS-alg.actX (fix-eq ProcCCS-algF <* _) <* _ <* _) ∙ cong′ (isCCS-alg.actX (ProcCCS-alg _) a) (evalG-eq' P) 
+     ∙ sym (cong isCCS-alg.actX (fix-eq ProcCCS-algF <* _) <* _ <* _) ∙ congS (isCCS-alg.actX (ProcCCS-alg _) a) (evalG-eq' P) 
   evalG-eq' {n} (P ⊕ P₁) = 
     ((fix-eq eval-fun <* n) <* (P ⊕ P₁)) ∙ cong Fold (cong₂ _∪_
                  (sym ((cong Proc.Unfold (fix-eq eval-fun <* n <* P)) ∙ refl))
@@ -396,9 +396,9 @@ module _ (ih : ▹ ∀ {n} (P : CCS n) → Eval.eval _ P ≡  evalG P) where
     (fix-eq eval-fun <* n <* ν P)
     ∙ nu-stepF P
     ∙ sym (cong isCCS-alg.νX (fix-eq ProcCCS-algF <* _) <* (eval (suc n) P))
-    ∙ cong′ (isCCS-alg.νX (ProcCCS-alg _)) (evalG-eq' P)
+    ∙ congS (isCCS-alg.νX (ProcCCS-alg _)) (evalG-eq' P)
   evalG-eq' {n} (! P) = 
-    ((fix-eq eval-fun <* n <* (! P)) ∙ cong Fold (cong₂ _∪_ (stepL'-step P _ ∙ cong′ (SL'.stepL' (Unfold (eval _ P)))
+    ((fix-eq eval-fun <* n <* (! P)) ∙ cong Fold (cong₂ _∪_ (stepL'-step P _ ∙ congS (SL'.stepL' (Unfold (eval _ P)))
              (later-ext \ α → ih α (! P) ∙ cong !Proc (sym (ih α P)) ∙ (cong isCCS-alg.!X (fix-eq ProcCCS-algF <* _) <* eval n P)))
              (stepL'-step-g (SL.synchF (step P) (step P)) _ 
                ∙ cong₂ SL'.stepL' (synchF-step P P)

--- a/ccs/semantics/Coalgebra.agda
+++ b/ccs/semantics/Coalgebra.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --guarded #-}
+{-# OPTIONS --cubical --guarded -WnoUnsupportedIndexedMatch #-}
 
 open import Cubical.Data.Sum hiding (inl; inr) 
 open import Cubical.Data.Empty renaming (rec to ⊥-rec)

--- a/ccs/semantics/FullAbstraction.agda
+++ b/ccs/semantics/FullAbstraction.agda
@@ -78,10 +78,10 @@ module Bisim-≡ where
                                                   let ∈stepy = mapP∞-in {B = Step (\ n → ▹ (Proc n)) n} (λ x → x .theLabel , λ α → eval n (x .theX))
                                                                                   (a , _) (step q) m'' in
                                                          transport (cong (λ x → ⟨ x ∈ mapP∞ (λ x → (x .theLabel , λ α → eval n (x .theX))) (step y) ⟩)
-                                                                     (cong′ (a ,_) (later-ext \ α → sym (eq' α)) ∙ sym eq))
+                                                                     (congS (a ,_) (later-ext \ α → sym (eq' α)) ∙ sym eq))
                                                                      (subst (λ x → ⟨ (a , (λ α → eval n (x α))) ∈ mapP∞ (λ z → z .theLabel , (λ α → eval n (z .theX))) (step y) ⟩)
                                                                             (sym r')
-                                                                            (transport (cong ⟨_⟩ (cong₂ _∈_ (cong′ (a ,_) (later-ext \ α → sym (eval-≈ (q'c))))
+                                                                            (transport (cong ⟨_⟩ (cong₂ _∈_ (congS (a ,_) (later-ext \ α → sym (eval-≈ (q'c))))
                                                                               (λ i → Unfold ((sym (fix-eq eval-fun <* _ <* q) ∙ sym (eval-≈ qc) ∙ (fix-eq eval-fun <* _ <* y)) i))))  ∈stepy ))
                                                 }) m''
 
@@ -105,7 +105,7 @@ module Bisim-≡ where
         where
           a⟦p'⟧∈stepp = mapP∞-in {B = Step (\ n → ▹ Proc n) n} (λ x → x .theLabel , λ _ → eval n (x .theX)) (a , p') (step p)
                                                      ap'∈stepp
-          a⟦p'⟧∈stepq = transport (cong′
+          a⟦p'⟧∈stepq = transport (congS
                                                                 (λ x → ⟨ (a , \ _ → eval _ p') ∈ x ⟩)
                                                                 (sym (cong (λ x → Unfold (x n p)) (fix-eq (eval-fun)))
                                                                 ∙ (λ i → Unfold (e i))
@@ -125,9 +125,9 @@ module Bisim-≡ where
                       (e' : ▸ \ α → eval _ p' ≡ eval _ q') →
                       Σ (▹ CCS n) (λ q'' → (Σ _ \ Q' → (next Q' ≡ q'') × ⟨ (a , Q') ∈ step q ⟩) × (▸ (λ α → eval _ (p') ≡ eval _ (q'' α)))))
                    (\ q' aq'∈stepq e' → next q' , (_ , refl , aq'∈stepq) , e')
-                   (sym (cong′ theLabel e'))
+                   (sym (congS theLabel e'))
                    q' aq'∈stepq
-                   (λ α i → cong′ theX e' i α)
+                   (λ α i → congS theX e' i α)
                    
       lem : ▹ (∀ n (p q : CCS n) → eval n p ≡ eval n q → Bisim n p q) → ∀ n (p q : CCS n) → eval n p ≡ eval n q → SimF (\ α → Bisim) n p q
       lem ih n p q e .sim a p' = PT.rec squash₁ \ { (Q , Q' , Q'' , Qc , r , Q'c ,  ap'∈stepp) →
@@ -150,7 +150,7 @@ fullAbstract {n} P Q =
         (ifunExt \ _ → funExt (λ _ → funExt λ _ → funExt λ _ →
           cong fst (⇔toPath {P = _ , squash₁} {Q = _ , squash₁} (opsem→∈step2 _ _ _) (∈step→opsem2 _ _ _))))) ⟩
   BR.Bisim n P Q
-    ≡⟨ cong′ fst (⇔toPath {P = _ , BR.isPropBisim}{Q = _ , isSetProc _ _ _}
+    ≡⟨ congS fst (⇔toPath {P = _ , BR.isPropBisim}{Q = _ , isSetProc _ _ _}
              (λ b → (sym (evalG-eq P) ∙ Eval'.eval-eq' P) ∙ bisim-≡ n P Q b ∙ sym (Eval'.eval-eq' Q) ∙ evalG-eq Q)
              (λ eq → ≡-bisim n P Q (sym (Eval'.eval-eq' P) ∙ evalG-eq P ∙ eq ∙ sym (evalG-eq Q) ∙ Eval'.eval-eq' Q))) ⟩
   (evalX ProcCCS-alg P ≡ evalX ProcCCS-alg Q)

--- a/ccs/semantics/MapProcLemmata.agda
+++ b/ccs/semantics/MapProcLemmata.agda
@@ -36,7 +36,7 @@ end-map : ∀ {n m} (f : Name n → Name m) →
     mapProc n m f endProc ≡ endProc
 end-map {n}{m} f =
   cong Fold (mapProc'-eq' _ _ _ _
-            ∙ cong′ (mapProcF (next mapProc') _ _ f) (cong′ Unfold (cong (λ alg → isCCS-alg.endX (alg n)) (fix-eq ProcCCS-algF)))
+            ∙ congS (mapProcF (next mapProc') _ _ f) (congS Unfold (cong (λ alg → isCCS-alg.endX (alg n)) (fix-eq ProcCCS-algF)))
             ∙ sym (cong Unfold (cong (λ alg → isCCS-alg.endX (alg m)) (fix-eq ProcCCS-algF))))
 
 -- mapProc and actProc.
@@ -44,17 +44,17 @@ act-map : ∀ {n m} (f : Name n → Name m) a P →
   mapProc _ _ f (actProc a P) ≡ actProc (mapAct f a) (mapProc _ _ f P)
 act-map {n}{m} f a P = 
   cong Fold (mapProc'-eq' _ _ _ _
-            ∙ cong′ (mapProcF (next mapProc') _ _ f) (cong′ Unfold (cong (λ alg → isCCS-alg.actX (alg n) a P) (fix-eq ProcCCS-algF)))
-            ∙ sym (cong′ Unfold (cong (λ alg → isCCS-alg.actX (alg m) (mapAct f a) (mapProc _ _ f P)) (fix-eq ProcCCS-algF))))
+            ∙ congS (mapProcF (next mapProc') _ _ f) (congS Unfold (cong (λ alg → isCCS-alg.actX (alg n) a P) (fix-eq ProcCCS-algF)))
+            ∙ sym (congS Unfold (cong (λ alg → isCCS-alg.actX (alg m) (mapAct f a) (mapProc _ _ f P)) (fix-eq ProcCCS-algF))))
 
 -- mapProc and sumProc.
 sum-map : ∀ {n m} (f : Name n → Name m) P Q →
   mapProc n m f (sumProc P Q) ≡ sumProc (mapProc n m f P) (mapProc n m f Q)
 sum-map {n}{m} f P Q =
   cong Fold (mapProc'-eq' _ _ _ _
-            ∙ cong′ (mapProcF (next mapProc') _ _ f) (cong′ Unfold (cong (λ alg → isCCS-alg.sumX (alg n) P Q) (fix-eq ProcCCS-algF)))
+            ∙ congS (mapProcF (next mapProc') _ _ f) (congS Unfold (cong (λ alg → isCCS-alg.sumX (alg n) P Q) (fix-eq ProcCCS-algF)))
             ∙ cong₂ _∪_ (sym (mapProc'-eq' _ _ _ _)) (sym (mapProc'-eq' _ _ _ _))
-            ∙ sym (cong′ Unfold (cong (λ alg → isCCS-alg.sumX (alg _) (mapProc _ _ f P) (mapProc _ _ f Q)) (fix-eq ProcCCS-algF))))
+            ∙ sym (congS Unfold (cong (λ alg → isCCS-alg.sumX (alg _) (mapProc _ _ f P) (mapProc _ _ f Q)) (fix-eq ProcCCS-algF))))
 
 -- mapProc and νProc (which requires some extra lemmata).
 no-stepν-inp : ∀ {n} P → stepν (`inp (fresh n) P) ≡ ø
@@ -64,12 +64,12 @@ no-stepν-inp P | nope x = refl
 
 stepν-inp : ∀ {n} a P → stepν {n} (`inp (ι a) P) ≡ η (`inp a λ α → νProc (P α) )
 stepν-inp a P with canNu? (inp (ι a))
-stepν-inp a P | inp x = cong′ η (StepPath (cong′ inp (sym (ι-inj _ _ x))) refl)
+stepν-inp a P | inp x = congS η (StepPath (congS inp (sym (ι-inj _ _ x))) refl)
 stepν-inp a P | nope (inp x) = ⊥-rec (fresh-ι x)
 
 stepν-out : ∀ {n} a P → stepν {n} (`out (ι a) P) ≡ η (`out a λ α → νProc (P α) )
 stepν-out a P with canNu? (out (ι a))
-stepν-out a P | out x = cong′ η (StepPath (cong′ out (sym (ι-inj _ _ x))) refl)
+stepν-out a P | out x = congS η (StepPath (congS out (sym (ι-inj _ _ x))) refl)
 stepν-out a P | nope (out x) = ⊥-rec (fresh-ι x)
 
 no-stepν : ∀ {n} {aP : Step (\ n → ▹ Proc n) (suc n)} → CannotNu (theLabel aP) → stepν aP ≡ ø
@@ -86,7 +86,7 @@ no-stepν {n} {.τ , P} () | τ
 ν-mapF n m f (`out a P) ih | out r | out x with decName a (fresh n)
 ... | yes p = ⊥-rec (fresh-ι (sym x))
 ν-mapF n m f (out a , P) ih | out {a = a₁} r | out x | no ¬p = 
-  cong η (StepPath (cong′ out (ι-inj _ _ (cong ι (cong f lem) ∙ x))) (later-ext (λ α → ih α _ _ f (P α))))
+  cong η (StepPath (congS out (ι-inj _ _ (cong ι (cong f lem) ∙ x))) (later-ext (λ α → ih α _ _ f (P α))))
     where
       lem : a₁ ≡ down a ¬p
       lem = J (λ y eq → (q : ¬ y ≡ fresh n) → a₁ ≡ down y q)
@@ -103,7 +103,7 @@ no-stepν {n} {.τ , P} () | τ
 ν-mapF n m f (`inp a P) ih | inp {a = a₁} r | inp x with decName a (fresh n)
 ... | yes p = ⊥-rec (fresh-ι (sym x))
 ... | no ¬p =
-  cong η (StepPath (cong′ inp (ι-inj _ _ (cong ι (cong f lem) ∙ x))) (later-ext (λ α → ih α _ _ f (P α))))
+  cong η (StepPath (congS inp (ι-inj _ _ (cong ι (cong f lem) ∙ x))) (later-ext (λ α → ih α _ _ f (P α))))
     where
       lem : a₁ ≡ down a ¬p
       lem = J (λ y eq → (q : ¬ y ≡ fresh n) → a₁ ≡ down y q)
@@ -120,11 +120,11 @@ no-stepν {n} {.τ , P} () | τ
 
 ν-map : ∀ n m (f : Name n → Name m) p
   → mapProc _ _ f (νProc p) ≡ νProc (mapProc _ _ (lift f) p)
-ν-map = fix (\ ih n m f p → cong Fold (mapProc'-eq' _ _ f (Unfold (νProc p))) ∙ cong′ (\ p → Fold (mapProcF (next mapProc') _ _ f (Unfold p)))
+ν-map = fix (\ ih n m f p → cong Fold (mapProc'-eq' _ _ f (Unfold (νProc p))) ∙ congS (\ p → Fold (mapProcF (next mapProc') _ _ f (Unfold p)))
       (cong (λ alg → isCCS-alg.νX (alg n) p) (fix-eq ProcCCS-algF))
       ∙ cong Fold
              (map-bind (Unfold p) _ _
-              ∙ cong′ (bind (Unfold p)) (funExt \ v → ν-mapF n m f v ih)
+              ∙ congS (bind (Unfold p)) (funExt \ v → ν-mapF n m f v ih)
               ∙ sym (bind-map (Unfold p) _ _))
       ∙ sym \ i → isCCS-alg.νX (fix-eq ProcCCS-algF i _) (Fold (mapProc'-eq' _ _ (lift f) (Unfold p) i)))
 
@@ -152,7 +152,7 @@ stepL-map : (ih : ▹
 stepL-map ih n m f p q =
   mapProc'-eq' _ _ _ (stepL (Unfold p) q) 
   ∙ mapmapP∞ _ _ (Unfold p)
-  ∙ cong′ (λ x → mapP∞ x (Unfold p)) (funExt (λ x →
+  ∙ congS (λ x → mapP∞ x (Unfold p)) (funExt (λ x →
             StepPath refl (later-ext (λ α → ih α _ _ f _ _))))
   ∙ sym (mapmapP∞ _ _ (Unfold p))
   ∙ cong₂ stepL (sym (mapProc'-eq' _ _ _ (Unfold p))) refl
@@ -167,7 +167,7 @@ stepR-map : (ih : ▹
 stepR-map ih n m f p q =
   mapProc'-eq' _ _ _ (stepR p (Unfold q)) 
   ∙ mapmapP∞ _ _ (Unfold q)
-  ∙ cong′ (λ x → mapP∞ x (Unfold q)) (funExt (λ x →
+  ∙ congS (λ x → mapP∞ x (Unfold q)) (funExt (λ x →
             StepPath refl (later-ext (λ α → ih α _ _ f _ _))))
   ∙ sym (mapmapP∞ _ _ (Unfold q))
   ∙ cong₂ stepR refl (sym (mapProc'-eq' _ _ _ (Unfold q)))
@@ -180,7 +180,7 @@ synch'-map n m f (`out x P) (`out y Q)  parX ih = refl
 synch'-map n m f (`out x P) (`inp y Q)  parX ih with decName x y 
 synch'-map n m f (`out x P) (`inp y Q)  parX ih | yes eq  =
   sym (synch'-out-inp _ _ _ (cong (fst f) eq) 
-  ∙ cong′ η (cong′ `τ (later-ext \ α → sym (ih α _ _ f _ _))))
+  ∙ congS η (congS `τ (later-ext \ α → sym (ih α _ _ f _ _))))
 synch'-map n m f (`out x P) (`inp y Q)  parX ih | no ¬eq =
   sym (no-synch'-out-inp _ _ _ \ x → ¬eq (f .snd _ _ x)) 
 synch'-map n m f (`out x P) (`τ Q)  parX ih = refl
@@ -193,7 +193,7 @@ synch'-map n m f (`τ P) (`τ Q)  parX ih = refl
 
 synchF-eq : ∀ {n} (p q : F' n (\ _ → Proc))
   → synchF p q ≡ synchF' (λ _ → parProc) p q ∪ synchF' (next (λ x y → parProc y x)) q p
-synchF-eq p q = cong′ (bind p) (funExt (λ _ → bind-∪ _ _ q)) ∙ bind-∪ _ _ p ∙ cong₂ _∪_ refl (bind-comm _ p q)
+synchF-eq p q = congS (bind p) (funExt (λ _ → bind-∪ _ _ q)) ∙ bind-∪ _ _ p ∙ cong₂ _∪_ refl (bind-comm _ p q)
 
 synch-map :
    (ih : ▹ (∀ n m (f : Inj n m) p q → mapProc n m (fst f) (parProc p q) ≡ parProc (mapProc _ _ (fst f) p) (mapProc _ _ (fst f) q))) →
@@ -210,9 +210,9 @@ synchF-map :
 synchF-map ih n m f v v' =
   mapProc'-eq' _ _ _ _
   ∙ map-bind  v _ _
-  ∙ cong′ (bind v) (funExt λ aP →
+  ∙ congS (bind v) (funExt λ aP →
       map-bind  v' _ _
-      ∙ cong′ (bind v') (funExt λ aQ →
+      ∙ congS (bind v') (funExt λ aQ →
           synch-map ih n m f aP aQ)
       ∙ sym (bind-map v' _ _))
   ∙ sym (bind-map v _ _)
@@ -222,22 +222,22 @@ par-map : ∀ n m (f : Inj n m) P Q →
   mapProc n m (fst f) (parProc P Q) ≡ parProc (mapProc _ _ (fst f) P) (mapProc _ _ (fst f) Q)
 par-map = fix \ ih n m f P Q →
   cong Fold (mapProc'-eq' _ _ _ _
-            ∙ cong′ (mapProcF (next mapProc') _ _ (fst f)) (cong′ Unfold (cong (λ alg → isCCS-alg.parX (alg n) P Q) (fix-eq ProcCCS-algF)))
+            ∙ congS (mapProcF (next mapProc') _ _ (fst f)) (congS Unfold (cong (λ alg → isCCS-alg.parX (alg n) P Q) (fix-eq ProcCCS-algF)))
             ∙ cong₂ _∪_ (cong₂ _∪_
                 (sym (mapProc'-eq' _ _ _ _) ∙ stepL-map ih _ _ f P Q) 
                 (sym (mapProc'-eq' _ _ _ _) ∙ stepR-map ih _ _ f P Q))
                 (sym (mapProc'-eq' _ _ _ _) ∙ synchF-map ih _ _ f (Unfold P) (Unfold Q))
-            ∙ sym (cong′ Unfold (cong (λ alg → isCCS-alg.parX (alg _) (mapProc _ _ (fst f) P) (mapProc _ _ (fst f) Q)) (fix-eq ProcCCS-algF))))
+            ∙ sym (congS Unfold (cong (λ alg → isCCS-alg.parX (alg _) (mapProc _ _ (fst f) P) (mapProc _ _ (fst f) Q)) (fix-eq ProcCCS-algF))))
 
 -- mapProc and !Proc.
 rep-map : ∀ {n m} (f : Inj n m) (P : Proc n) →
   mapProc n m (fst f) (!Proc P) ≡ !Proc (mapProc _ _ (fst f) P) 
 rep-map = fix λ ih f P →
-  cong′ (mapProc _ _ (fst f)) (!Proc-eq {P = P})
+  congS (mapProc _ _ (fst f)) (!Proc-eq {P = P})
   ∙ cong Fold
       (∪-map (fst f) _ _
       ∙ cong₂ _∪_ (stepL-map (next par-map) _ _ f P (!Proc P)
-                  ∙ cong′ (stepL' (Unfold (mapProc _ _ (fst f) P))) (later-ext (λ α → ih α f P)))
+                  ∙ congS (stepL' (Unfold (mapProc _ _ (fst f) P))) (later-ext (λ α → ih α f P)))
                   (stepL-map (next par-map) _ _ f (Fold (synchF (Unfold P) (Unfold P))) (!Proc P)
                   ∙ cong₂ stepL' (synchF-map (next par-map) _ _ f (Unfold P) (Unfold P)) (later-ext (λ α → ih α f P))))
   ∙ sym (!Proc-eq {P = mapProc _ _ (fst f) P})
@@ -258,8 +258,8 @@ mapProc-evalX f (p ∣∣ q) =
   cong₂ parProc (mapProc-evalX f p) (mapProc-evalX f q)
   ∙ sym (par-map _ _ f _ _)
 mapProc-evalX f (ν p) =
-  cong′ νProc (mapProc-evalX (lift (fst f) , lift-inj f) p)
+  congS νProc (mapProc-evalX (lift (fst f) , lift-inj f) p)
   ∙ sym (ν-map _ _ (fst f) _)
 mapProc-evalX f (! p) =
-  cong′ !Proc (mapProc-evalX f p)
+  congS !Proc (mapProc-evalX f p)
   ∙ sym (rep-map f _)

--- a/ccs/semantics/MapProcLemmata.agda
+++ b/ccs/semantics/MapProcLemmata.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --guarded #-}
+{-# OPTIONS --cubical --guarded -WnoUnsupportedIndexedMatch #-}
 open import Cubical.Data.Sum hiding (inl; inr)
 open import Cubical.Data.Empty renaming (rec to ⊥-rec)
 open import Cubical.Data.Nat

--- a/ccs/semantics/StructuralCongruence.agda
+++ b/ccs/semantics/StructuralCongruence.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --guarded #-}
+{-# OPTIONS --cubical --guarded -WnoUnsupportedIndexedMatch #-}
 
 open import Cubical.Data.Sum hiding (inl; inr) 
 open import Cubical.Data.Empty renaming (rec to ⊥-rec)

--- a/ccs/semantics/StructuralCongruence.agda
+++ b/ccs/semantics/StructuralCongruence.agda
@@ -49,10 +49,10 @@ module _ (ih : ▹ StructCong ProcCCS-alg (mapProc-Inj _ _) _≡_) where
 -- Unitality of parProc.
   unit-par : ∀ {n} {P : Proc n} → parProc P endProc ≡ P
   unit-par {n}{P} =
-    cong′ (λ x → isCCS-alg.parX (x n) P (isCCS-alg.endX (x n))) (fix-eq ProcCCS-algF)
+    congS (λ x → isCCS-alg.parX (x n) P (isCCS-alg.endX (x n))) (fix-eq ProcCCS-algF)
     ∙ cong Fold (cong₂ _∪_ (unit _) (bind-ø (Unfold P))
                 ∙ unit _
-                ∙ cong′ (λ x → mapP∞ x (Unfold P)) (funExt (λ {(a , P') → StepPath refl
+                ∙ congS (λ x → mapP∞ x (Unfold P)) (funExt (λ {(a , P') → StepPath refl
                   (later-ext (\ α → unit∣∣X (ih α))) }))
                 ∙ mapidP∞ _)
 
@@ -74,21 +74,21 @@ module _ (ih : ▹ StructCong ProcCCS-alg (mapProc-Inj _ _) _≡_) where
 
   comm-par : ∀ {n} {p q : Proc n} → parProc p q ≡ parProc q p
   comm-par {n}{P}{Q} =
-    cong′ (λ x → isCCS-alg.parX (x n) P Q) (fix-eq ProcCCS-algF)
+    congS (λ x → isCCS-alg.parX (x n) P Q) (fix-eq ProcCCS-algF)
     ∙ cong Fold (cong₂ _∪_
                   (cong₂ _∪_
-                    (cong′ (λ f → mapP∞ f (Unfold P)) (funExt (λ _ → StepPath refl (later-ext (\ α → ih α .comm∣∣X {Q = Q}))))) 
-                    (cong′ (λ f → mapP∞ f (Unfold Q)) (funExt (λ _ → StepPath refl (later-ext (\ α → ih α .comm∣∣X {P = P})))))
+                    (congS (λ f → mapP∞ f (Unfold P)) (funExt (λ _ → StepPath refl (later-ext (\ α → ih α .comm∣∣X {Q = Q}))))) 
+                    (congS (λ f → mapP∞ f (Unfold Q)) (funExt (λ _ → StepPath refl (later-ext (\ α → ih α .comm∣∣X {P = P})))))
                   ∙ comm _ _)
                   (comm-synchF {_}{Unfold P}{Unfold Q}))
-    ∙ cong′ (λ x → isCCS-alg.parX (x n) Q P) (sym (fix-eq ProcCCS-algF))
+    ∙ congS (λ x → isCCS-alg.parX (x n) Q P) (sym (fix-eq ProcCCS-algF))
 
 -- Associativity of parProc.
   step-LR : ∀ {n} P Q R →
     stepL {n} (stepR P Q) R ≡ stepR P (stepL Q R)
   step-LR P Q R =
     mapmapP∞ _ _ Q
-    ∙ cong′ (λ f → mapP∞ f Q) (funExt (λ { (a , Q') →
+    ∙ congS (λ f → mapP∞ f Q) (funExt (λ { (a , Q') →
         StepPath refl (later-ext (λ α → ih α .assoc∣∣X {P = P})) })) ∙ sym (mapmapP∞ _ _ Q)
 
 -- Associativity of parProc (which requires many lemmata).
@@ -96,7 +96,7 @@ module _ (ih : ▹ StructCong ProcCCS-alg (mapProc-Inj _ _) _≡_) where
     stepR {n} P (stepR Q R) ≡ stepR (parProc P Q) R
   step-RR P Q R =
     mapmapP∞ _ _ R
-    ∙ sym (cong′ (λ f → mapP∞ f R) (funExt (λ { (a , R') →
+    ∙ sym (congS (λ f → mapP∞ f R) (funExt (λ { (a , R') →
         StepPath refl (later-ext (λ α → ih α .assoc∣∣X {P = P}))})))
 
   stepL-synch'-L : ∀ {n} (aP aQ : Step (\ n → ▹ Proc n) n) R →
@@ -175,12 +175,12 @@ module _ (ih : ▹ StructCong ProcCCS-alg (mapProc-Inj _ _) _≡_) where
         cong (bind R) (funExt (λ aR' →
           cong₂ _∪_
             (synch'-assoc aP' Q aR')
-            (cong′ (λ (f : ▹ (∀ n → Proc n → Proc n → Proc n)) → synch' (λ α {n} → f α n) aR' (theLabel aP' , λ α → parProc (theX aP' α) Q)) 
+            (congS (λ (f : ▹ (∀ n → Proc n → Proc n → Proc n)) → synch' (λ α {n} → f α n) aR' (theLabel aP' , λ α → parProc (theX aP' α) Q)) 
               (later-ext (λ α → funExt (λ _ → funExt (λ p → (funExt (λ q → ih α .comm∣∣X {P = q}))))))
-             ∙ cong′ (synch' (λ _ → parProc) aR') (StepPath refl (later-ext (λ α → ih α .comm∣∣X {P = theX aP' α})))
+             ∙ congS (synch' (λ _ → parProc) aR') (StepPath refl (later-ext (λ α → ih α .comm∣∣X {P = theX aP' α})))
              ∙ sym (synch'-assoc aR' Q aP')
-             ∙ cong′ (λ x → synch' (λ _ → parProc) x aP') (StepPath refl (later-ext (λ α → ih α .comm∣∣X {P = theX aR' α})))
-             ∙ cong′ (λ (f : ▹ (∀ n → Proc n → Proc n → Proc n)) → synch' (λ α {n} → f α n) (theLabel aR' , λ α → parProc Q (theX aR' α)) aP')
+             ∙ congS (λ x → synch' (λ _ → parProc) x aP') (StepPath refl (later-ext (λ α → ih α .comm∣∣X {P = theX aR' α})))
+             ∙ congS (λ (f : ▹ (∀ n → Proc n → Proc n → Proc n)) → synch' (λ α {n} → f α n) (theLabel aR' , λ α → parProc Q (theX aR' α)) aP')
                 (later-ext (λ α → funExt (λ _ → funExt (λ p → (funExt (λ q → ih α .comm∣∣X {P = p})))))))))
         ∙ sym (bind-map R _ _)))
 
@@ -206,14 +206,14 @@ module _ (ih : ▹ StructCong ProcCCS-alg (mapProc-Inj _ _) _≡_) where
 
   synchsynchF : ∀ {n} (P : F' n (\ _ → Proc)) Q R →
      synchF P (synchF Q R) ≡ ø
-  synchsynchF P Q R = cong′ (bind P) (funExt \ a' → bind-bind Q _ _ ∙ cong′ (bind Q) (funExt \ b' → bind-bind R _ _ ∙ cong′ (bind R)
+  synchsynchF P Q R = congS (bind P) (funExt \ a' → bind-bind Q _ _ ∙ congS (bind Q) (funExt \ b' → bind-bind R _ _ ∙ congS (bind R)
     (funExt \ c' → synchsynch b' c' a') ∙ bind-ø R) ∙ bind-ø Q) ∙ bind-ø P
 
   step-LL : ∀ {n} P Q R →
     stepL {n} (stepL P Q) R ≡ stepL P (parProc Q R)
   step-LL {n} P Q R =
     mapmapP∞ _ _ P
-    ∙ cong′ (λ f → mapP∞ f P) (funExt (λ { (a , P') →
+    ∙ congS (λ f → mapP∞ f P) (funExt (λ { (a , P') →
         StepPath refl (later-ext (λ α →  assoc∣∣X (ih α) {P = _}{Q}{R}))}))
 
   assoc-synchF : ∀ {n} (P : F' n (\ _ → Proc)) Q R →
@@ -223,19 +223,19 @@ module _ (ih : ▹ StructCong ProcCCS-alg (mapProc-Inj _ _) _≡_) where
 
   assoc-par : ∀ {n} {P Q R : Proc n} → parProc (parProc P Q) R ≡ parProc P (parProc Q R)
   assoc-par {n}{P}{Q}{R} =
-   cong₂ parProc (cong′ (λ x → isCCS-alg.parX (x n) P Q) (fix-eq ProcCCS-algF)) refl
-   ∙ cong′ (λ x → isCCS-alg.parX (x n) (isCCS-alg.parX (fix-eq ProcCCS-algF i1 n) P Q) R) (fix-eq ProcCCS-algF)
+   cong₂ parProc (congS (λ x → isCCS-alg.parX (x n) P Q) (fix-eq ProcCCS-algF)) refl
+   ∙ congS (λ x → isCCS-alg.parX (x n) (isCCS-alg.parX (fix-eq ProcCCS-algF i1 n) P Q) R) (fix-eq ProcCCS-algF)
    ∙ cong Fold (sym (assoc _ _ _ ∙ assoc _ _ _ ∙ assoc _ _ _)
                 ∙ cong₂ _∪_
                     (step-LL (Unfold P) Q R
-                     ∙ cong′ (λ f → mapP∞ f (Unfold P)) (funExt (λ P' →
-                             StepPath refl (later-ext (λ α → cong₂ parProc refl (cong′ (λ x → isCCS-alg.parX (x n) Q R) (fix-eq ProcCCS-algF)))))))
+                     ∙ congS (λ f → mapP∞ f (Unfold P)) (funExt (λ P' →
+                             StepPath refl (later-ext (λ α → cong₂ parProc refl (congS (λ x → isCCS-alg.parX (x n) Q R) (fix-eq ProcCCS-algF)))))))
                     (cong₂ _∪_ (step-LR P (Unfold Q) R)
                       (comm _ _ ∙ sym (assoc _ _ _)
                        ∙ cong₂ _∪_
                            (sym (step-RR P Q (Unfold R)
-                            ∙ cong′ (λ f → mapP∞ f (Unfold R)) (funExt (λ R' →
-                                    StepPath refl (later-ext (λ α → cong₂ parProc (cong′ (λ x → isCCS-alg.parX (x n) P Q) (fix-eq ProcCCS-algF)) refl))))))
+                            ∙ congS (λ f → mapP∞ f (Unfold R)) (funExt (λ R' →
+                                    StepPath refl (later-ext (λ α → cong₂ parProc (congS (λ x → isCCS-alg.parX (x n) P Q) (fix-eq ProcCCS-algF)) refl))))))
                            (comm _ _
                             ∙ cong₂ _∪_
                                 (synchF-L (Unfold P) (Unfold Q) R ∙ sym (bind-comm _ (stepL (Unfold Q) R) (Unfold P)))
@@ -258,27 +258,27 @@ module _ (ih : ▹ StructCong ProcCCS-alg (mapProc-Inj _ _) _≡_) where
                             ∙ cong₂ _∪_ refl (bind-comm _ (Unfold (isCCS-alg.parX (fix-eq ProcCCS-algF i1 n) Q R)) (Unfold P))))
                      ∙ assoc _ _ _ ∙ assoc _ _ _)
                 ∙ assoc _ _ _)
-   ∙ sym (cong′ (λ x → isCCS-alg.parX (x n) P (isCCS-alg.parX (fix-eq ProcCCS-algF i1 n) Q R)) (fix-eq ProcCCS-algF))
-   ∙ sym (cong₂ parProc refl (cong′ (λ x → isCCS-alg.parX (x n) Q R) (fix-eq ProcCCS-algF)))
+   ∙ sym (congS (λ x → isCCS-alg.parX (x n) P (isCCS-alg.parX (fix-eq ProcCCS-algF i1 n) Q R)) (fix-eq ProcCCS-algF))
+   ∙ sym (cong₂ parProc refl (congS (λ x → isCCS-alg.parX (x n) Q R) (fix-eq ProcCCS-algF)))
 
 -- The equation characterizing replication as iterated parallel composition.
   synch-! : ∀ {n} (P : Proc n)
     → stepL (synchF (Unfold P) (Unfold P)) (!Proc P) ≡ synchF (Unfold P) (Unfold (!Proc P))
   synch-! P =
     sym (unit _)
-    ∙ cong₂ _∪_ refl (sym (cong′ (λ P' → stepL P' (!Proc P)) (synchsynchF (Unfold P) (Unfold P) (Unfold P))))
+    ∙ cong₂ _∪_ refl (sym (congS (λ P' → stepL P' (!Proc P)) (synchsynchF (Unfold P) (Unfold P) (Unfold P))))
     ∙ cong₂ _∪_ (synchF-L (Unfold P) (Unfold P) (!Proc P) ∙ bind-comm _ (Unfold P) (stepL (Unfold P) (!Proc P)))
                 (synchF-L (Unfold P) (synchF (Unfold P) (Unfold P)) (!Proc P) ∙ bind-comm _ (Unfold P) (stepL (synchF (Unfold P) (Unfold P)) (!Proc P)))
     ∙ bind-comm _ (stepL (Unfold P) (!Proc P) ∪ stepL (synchF (Unfold P) (Unfold P)) (!Proc P)) (Unfold P)
-    ∙ cong′ (synchF (Unfold P)) (cong Unfold (sym (!Proc-eq {_}{P})))
+    ∙ congS (synchF (Unfold P)) (cong Unfold (sym (!Proc-eq {_}{P})))
 
   stepR-! : ∀ {n} {P : Proc n} → stepR P (Unfold (!Proc P)) ≡ Unfold (!Proc P)
   stepR-! {_}{P} =
     cong₂ mapP∞ (funExt (λ aP' → StepPath refl (later-ext (λ α → ih α .comm∣∣X {P = P})))) (refl {x = Unfold (!Proc P)})
     ∙ cong₂ stepL (cong Unfold (!Proc-eq {_}{P})) refl
     ∙ cong₂ _∪_
-        (step-LL (Unfold P) (!Proc P) P ∙ cong′ (stepL' (Unfold P)) (later-ext (λ α → ih α .comm∣∣X {P = !Proc P} ∙ sym (ih α .replX {P = P}))))
-        (step-LL (synchF (Unfold P) (Unfold P)) (!Proc P) P ∙ cong′ (stepL' (synchF (Unfold P) (Unfold P))) (later-ext (λ α → ih α .comm∣∣X {P = !Proc P} ∙ sym (ih α .replX {P = P}))))
+        (step-LL (Unfold P) (!Proc P) P ∙ congS (stepL' (Unfold P)) (later-ext (λ α → ih α .comm∣∣X {P = !Proc P} ∙ sym (ih α .replX {P = P}))))
+        (step-LL (synchF (Unfold P) (Unfold P)) (!Proc P) P ∙ congS (stepL' (synchF (Unfold P) (Unfold P))) (later-ext (λ α → ih α .comm∣∣X {P = !Proc P} ∙ sym (ih α .replX {P = P}))))
     ∙ cong Unfold (sym (!Proc-eq {P = P}))
 
   repl-par : ∀ {n} {P : Proc n} → !Proc P ≡ parProc P (!Proc P)
@@ -296,7 +296,7 @@ module _ (ih : ▹ StructCong ProcCCS-alg (mapProc-Inj _ _) _≡_) where
        ≡⟨ cong₂ _∪_ (comm _ _) refl ⟩
        (stepL (Unfold P) (!Proc P) ∪ stepR P (Unfold (!Proc P))) ∪ synchF (Unfold P) (Unfold (!Proc P))
        ∎)
-    ∙ cong′ (λ x → isCCS-alg.parX (x _) P (isCCS-alg.!X (fix-eq ProcCCS-algF i0 _) P)) (sym (fix-eq ProcCCS-algF))
+    ∙ congS (λ x → isCCS-alg.parX (x _) P (isCCS-alg.!X (fix-eq ProcCCS-algF i0 _) P)) (sym (fix-eq ProcCCS-algF))
 
 -- Restriction of the nil process.
   ν-end : ∀ {n} → νProc endProc ≡ endProc {n}
@@ -317,12 +317,12 @@ module _ (ih : ▹ StructCong ProcCCS-alg (mapProc-Inj _ _) _≡_) where
     νProc (Fold (stepL (Unfold P) (mapProc m _ ι Q)))
     ≡ Fold (stepL (Unfold (νProc P)) Q)
   ν-stepL {n}{P}{Q} =
-    cong′ (λ x → isCCS-alg.νX (x _) (Fold (stepL (Unfold P) (mapProc n _ ι Q)))) (fix-eq ProcCCS-algF)
+    congS (λ x → isCCS-alg.νX (x _) (Fold (stepL (Unfold P) (mapProc n _ ι Q)))) (fix-eq ProcCCS-algF)
     ∙ cong Fold
         (bind-map (Unfold P) _ _
          ∙ cong (bind (Unfold P)) (funExt (λ aP' → ν-stepL' aP' Q))
          ∙ sym (map-bind (Unfold P) _ _))
-    ∙ cong′ (λ x → Fold (stepL (Unfold (isCCS-alg.νX (x _) P)) Q)) (sym (fix-eq ProcCCS-algF))
+    ∙ congS (λ x → Fold (stepL (Unfold (isCCS-alg.νX (x _) P)) Q)) (sym (fix-eq ProcCCS-algF))
 
   ν-stepR' : ∀ {n} P (aQ : Step (\ n → ▹ Proc n) n) →
     stepν {n} (mapAct ι (theLabel aQ) , (λ α → parProc P (mapProc _ _ ι (theX aQ α))))
@@ -330,22 +330,22 @@ module _ (ih : ▹ StructCong ProcCCS-alg (mapProc-Inj _ _) _≡_) where
   ν-stepR' P (`out a Q) with decName (ι a) (fresh _)
   ... | yes p = ⊥-rec (fresh-ι p)
   ... | no p =
-    cong′ η (StepPath (cong′ out (down-ι p)) (later-ext (λ α → ih α .ν∣∣X)))
+    congS η (StepPath (congS out (down-ι p)) (later-ext (λ α → ih α .ν∣∣X)))
   ν-stepR' P (`inp a Q) with decName (ι a) (fresh _)
   ... | yes p = ⊥-rec (fresh-ι p)
   ... | no p =
-    cong′ η (StepPath (cong′ inp (down-ι p)) (later-ext (λ α → ih α .ν∣∣X)))
-  ν-stepR' P (`τ Q) = cong′ η (StepPath refl (later-ext (λ α → ih α .ν∣∣X)))
+    congS η (StepPath (congS inp (down-ι p)) (later-ext (λ α → ih α .ν∣∣X)))
+  ν-stepR' P (`τ Q) = congS η (StepPath refl (later-ext (λ α → ih α .ν∣∣X)))
 
   ν-stepR : ∀ {m P Q} →
     νProc (Fold (stepR P (Unfold (mapProc m _ ι Q)))) ≡ Fold (stepR (νProc P) (Unfold Q))
   ν-stepR {m} {P} {Q} =
-    cong′ νProc (cong′ Fold (cong′ (stepR P) (mapProc'-eq' _ _ _ _)))
-    ∙ cong′ (λ x → isCCS-alg.νX (x _) (Fold (stepR P (mapProcF (next mapProc') m (suc m) ι (Unfold Q))))) (fix-eq ProcCCS-algF)
+    congS νProc (congS Fold (congS (stepR P) (mapProc'-eq' _ _ _ _)))
+    ∙ congS (λ x → isCCS-alg.νX (x _) (Fold (stepR P (mapProcF (next mapProc') m (suc m) ι (Unfold Q))))) (fix-eq ProcCCS-algF)
     ∙ cong Fold
-        (cong′ (λ x → bind x _) (mapmapP∞ _ _ (Unfold Q))
+        (congS (λ x → bind x _) (mapmapP∞ _ _ (Unfold Q))
          ∙ bind-map (Unfold Q) _ _
-         ∙ cong′ (bind (Unfold Q)) (funExt (ν-stepR' P))
+         ∙ congS (bind (Unfold Q)) (funExt (ν-stepR' P))
          ∙ sym (mapP∞-is-bind (Unfold Q)))
 
   ν-synch' : ∀ {n} aP aQ →
@@ -408,7 +408,7 @@ module _ (ih : ▹ StructCong ProcCCS-alg (mapProc-Inj _ _) _≡_) where
     νProc (Fold (synchF (Unfold P) (Unfold (mapProc m _ ι Q))))
     ≡ Fold (synchF (Unfold (νProc P)) (Unfold Q))
   ν-synchF {n} P Q = 
-    cong′ (λ x → isCCS-alg.νX (x _) (Fold (synchF (Unfold P) (Unfold (mapProc _ _ ι Q)))))
+    congS (λ x → isCCS-alg.νX (x _) (Fold (synchF (Unfold P) (Unfold (mapProc _ _ ι Q)))))
           (fix-eq ProcCCS-algF)
     ∙ cong Fold
            (bind-bind (Unfold P) _ _
@@ -423,19 +423,19 @@ module _ (ih : ▹ StructCong ProcCCS-alg (mapProc-Inj _ _) _≡_) where
                     ∙ sym (bind-∪ _ _ (stepν aP'))))
                 ∙ bind-comm _ (Unfold Q) (stepν aP')))
             ∙ sym (bind-bind (Unfold P) _ _))
-    ∙ cong′ (λ x → Fold (synchF (Unfold (isCCS-alg.νX (x _) P)) (Unfold Q)))
+    ∙ congS (λ x → Fold (synchF (Unfold (isCCS-alg.νX (x _) P)) (Unfold Q)))
             (sym (fix-eq ProcCCS-algF))      
 
   ν-par : ∀ {m P Q} → νProc (parProc P (mapProc m _ ι Q)) ≡ parProc (νProc P) Q
   ν-par {n}{P}{Q} =
-    cong′ νProc (cong′ (λ x → isCCS-alg.parX (x _) P (mapProc n _ ι Q)) (fix-eq ProcCCS-algF))
-    ∙ cong′ (λ x → isCCS-alg.νX (x _) (isCCS-alg.parX (fix-eq ProcCCS-algF i1 _) P (mapProc n _ ι Q))) (fix-eq ProcCCS-algF)
+    congS νProc (congS (λ x → isCCS-alg.parX (x _) P (mapProc n _ ι Q)) (fix-eq ProcCCS-algF))
+    ∙ congS (λ x → isCCS-alg.νX (x _) (isCCS-alg.parX (fix-eq ProcCCS-algF i1 _) P (mapProc n _ ι Q))) (fix-eq ProcCCS-algF)
     ∙ cong Fold
         (cong₂ _∪_ (cong₂ _∪_
-                      (cong Unfold (cong′ (λ x → isCCS-alg.νX (x _) (Fold (stepL (Unfold P) (mapProc n _ ι Q)))) (sym (fix-eq ProcCCS-algF)) ∙ (ν-stepL {P = P})))
-                      (cong Unfold (cong′ (λ x → isCCS-alg.νX (x _) (Fold (stepR P (Unfold (mapProc n _ ι Q))))) (sym (fix-eq ProcCCS-algF)) ∙ ν-stepR)))
-                   (cong Unfold (cong′ (λ x → isCCS-alg.νX (x _) (Fold (synchF (Unfold P) (Unfold (mapProc _ _ ι Q))))) (sym (fix-eq ProcCCS-algF)) ∙ ν-synchF P Q)))
-    ∙ cong′ (λ x → isCCS-alg.parX (x _) (νProc P) Q) (sym (fix-eq ProcCCS-algF))
+                      (cong Unfold (congS (λ x → isCCS-alg.νX (x _) (Fold (stepL (Unfold P) (mapProc n _ ι Q)))) (sym (fix-eq ProcCCS-algF)) ∙ (ν-stepL {P = P})))
+                      (cong Unfold (congS (λ x → isCCS-alg.νX (x _) (Fold (stepR P (Unfold (mapProc n _ ι Q))))) (sym (fix-eq ProcCCS-algF)) ∙ ν-stepR)))
+                   (cong Unfold (congS (λ x → isCCS-alg.νX (x _) (Fold (synchF (Unfold P) (Unfold (mapProc _ _ ι Q))))) (sym (fix-eq ProcCCS-algF)) ∙ ν-synchF P Q)))
+    ∙ congS (λ x → isCCS-alg.parX (x _) (νProc P) Q) (sym (fix-eq ProcCCS-algF))
 
 -- The equation stating that the order in which a process is
 -- restricted twice does not matter (again with some extra lemmata).
@@ -567,7 +567,7 @@ module _ (ih : ▹ StructCong ProcCCS-alg (mapProc-Inj _ _) _≡_) where
     Fold (bind (bind (Unfold P) stepν) stepν)
       ≡⟨ cong Fold (bind-bind (Unfold P) stepν stepν) ⟩
     Fold (bind (Unfold P) (λ x → bind (stepν x) stepν))
-      ≡⟨ cong Fold (cong′ (bind (Unfold P)) (funExt stepν-swap)) ⟩
+      ≡⟨ cong Fold (congS (bind (Unfold P)) (funExt stepν-swap)) ⟩
     Fold (bind (Unfold P) (λ x → bind (stepν (mapSProc' _ _ swap x)) stepν))
       ≡⟨ cong Fold (sym (bind-bind (Unfold P) _ _)) ⟩
     Fold (bind (bind (Unfold P) (λ x → stepν (mapSProc' _ _ swap x))) stepν)
@@ -586,11 +586,11 @@ module _ (ih : ▹ StructCong ProcCCS-alg (mapProc-Inj _ _) _≡_) where
        { refl≈X = refl
        ; sym≈X = sym
        ; _∙≈X_ = _∙_
-       ; cong·X = cong′ (actProc _)
+       ; cong·X = congS (actProc _)
        ; cong⊕X = λ eq1 eq2 → cong₂ sumProc eq1 eq2
        ; cong∣∣X = λ eq1 eq2 → cong₂ parProc eq1 eq2
-       ; congνX = cong′ νProc
-       ; cong!X = cong′ !Proc
+       ; congνX = congS νProc
+       ; cong!X = congS !Proc
        ; unit⊕X = unit-sum
        ; comm⊕X = comm-sum 
        ; assoc⊕X = assoc-sum

--- a/pi-calculus/Syntax.agda
+++ b/pi-calculus/Syntax.agda
@@ -57,9 +57,9 @@ mapPi f (! P) = ! (mapPi f P)
 
 mapPi-id : ∀ {n} (P : Pi n) → mapPi (λ x → x) P ≡ P
 mapPi-id end = refl
-mapPi-id (out ch x · P) = cong′ (out ch x ·_) (mapPi-id P)
-mapPi-id (inp ch · P) = cong′ (inp ch ·_) ((λ i → mapPi (λ v → lift-id v i) P) ∙ mapPi-id P)
-mapPi-id (τ · P) = cong′ (τ ·_) (mapPi-id P)
+mapPi-id (out ch x · P) = congS (out ch x ·_) (mapPi-id P)
+mapPi-id (inp ch · P) = congS (inp ch ·_) ((λ i → mapPi (λ v → lift-id v i) P) ∙ mapPi-id P)
+mapPi-id (τ · P) = congS (τ ·_) (mapPi-id P)
 mapPi-id (P ⊕ P₁) = cong₂ _⊕_ (mapPi-id P) (mapPi-id P₁)
 mapPi-id (P ∣∣ P₁) = cong₂ _∣∣_ (mapPi-id P) (mapPi-id P₁)
 mapPi-id (ν P) = cong ν ((λ i → mapPi (λ v → lift-id v i) P) ∙ mapPi-id P)

--- a/pi-calculus/semantics/Algebra.agda
+++ b/pi-calculus/semantics/Algebra.agda
@@ -189,10 +189,10 @@ mapSProc'-id ih m (`τ Q) = StepPath refl refl (later-ext (\ α → ih α _ _))
 mapProc-id : ∀ m Q → mapProc m m (\ x → x) Q ≡ Q
 mapProc-id = fix \ ih m Q → cong Fold (
   mapProc'-eq' _ _ _ _)
-  ∙ cong Fold (cong′ (bind (Unfold Q)) (funExt \ aq →
+  ∙ cong Fold (congS (bind (Unfold Q)) (funExt \ aq →
          inps-eq (\ x → x) aq _
          ∙ cong₂ _∪_ refl (inps'2-id aq)
-         ∙ unit _ ∙ cong′ η (mapSProc'-id ih _ aq)))
+         ∙ unit _ ∙ congS η (mapSProc'-id ih _ aq)))
   ∙ cong Fold (bind-η (Unfold Q))
 
 mapmapProc' : ∀ l m n (f : Inj _ _) (g : Name _ → Name _) p
@@ -201,19 +201,19 @@ mapmapProc' = fix \ where
   ih l m n f'@(f , f-inj) g'@(g) p →
     cong (mapProc _ _ _) (cong Fold (mapProc'-eq' _ _ _ _))
     ∙ cong Fold (mapProc'-eq' _ _ _ _)
-    ∙ cong Fold (bind-bind (Unfold p) _ _ ∙ cong′ (bind (Unfold p)) (funExt
-      (λ { (`τ q) → cong′ η (StepPath refl refl (later-ext (λ α → ih α _ _ _ f' g' (q α))))
-         ; (`out ch z q) → cong′ η (StepPath refl refl (later-ext (λ α → ih α _ _ _ f' g' (q α))))
-         ; (`inp ch v q) → cong′ η (StepPath refl refl (later-ext (λ α → ih α _ _ _ f' g' (q α))))
-         ; (`bout ch q) → cong′ η (StepPath refl refl (later-ext (λ α → ih α _ _ _ (lift f , lift-inj f') (lift g) (q α) ∙
-           cong Fold (cong′ (λ k → mapProc' _ _ k (Unfold (q α))) (λ i v → liftlift f g v i)))))
+    ∙ cong Fold (bind-bind (Unfold p) _ _ ∙ congS (bind (Unfold p)) (funExt
+      (λ { (`τ q) → congS η (StepPath refl refl (later-ext (λ α → ih α _ _ _ f' g' (q α))))
+         ; (`out ch z q) → congS η (StepPath refl refl (later-ext (λ α → ih α _ _ _ f' g' (q α))))
+         ; (`inp ch v q) → congS η (StepPath refl refl (later-ext (λ α → ih α _ _ _ f' g' (q α))))
+         ; (`bout ch q) → congS η (StepPath refl refl (later-ext (λ α → ih α _ _ _ (lift f , lift-inj f') (lift g) (q α) ∙
+           cong Fold (congS (λ k → mapProc' _ _ k (Unfold (q α))) (λ i v → liftlift f g v i)))))
          ; (`binp ch q) → sym (assoc _ _ _) ∙ cong₂ _∪_
-           (cong′ η (cong′ (`binp (f (g ch)))
-             (later-ext (λ α → ih α _ _ _ (lift f , lift-inj f') (lift g) (q α) ∙ cong Fold (cong′ (λ k → mapProc' _ _ k (Unfold (q α))) (λ i v → liftlift f g v i))))))
-           ( (cong₂ _∪_ (inps'-eq _ _ _ _ ∙ cong-bind (neg (image f) (image-fn _)) (\ z mz → cong′ η (cong′ (`inp (f (g ch)) z)
+           (congS η (congS (`binp (f (g ch)))
+             (later-ext (λ α → ih α _ _ _ (lift f , lift-inj f') (lift g) (q α) ∙ cong Fold (congS (λ k → mapProc' _ _ k (Unfold (q α))) (λ i v → liftlift f g v i))))))
+           ( (cong₂ _∪_ (inps'-eq _ _ _ _ ∙ cong-bind (neg (image f) (image-fn _)) (\ z mz → congS η (congS (`inp (f (g ch)) z)
              (later-ext \ α → ih α _ _ _ (snoc f z , snoc-inj f' z mz) (labelRen (binp ch) n g) (q α) ∙ cong₂ (mapProc _ _) (funExt \ x → snoc-lift f g z x) refl))))
                       (cong₂ bind (inps'-eq _ _ _ q) refl ∙ bind-bind (neg (image g) (image-fn _)) _ _)
-            ∙ (cong₂ _∪_ refl (cong-bind (neg (image g) (image-fn _)) (\ a ma → cong′ η (StepPath refl refl (later-ext \ α → ih α _ _ _ f' (_) (q α)
+            ∙ (cong₂ _∪_ refl (cong-bind (neg (image g) (image-fn _)) (\ a ma → congS η (StepPath refl refl (later-ext \ α → ih α _ _ _ f' (_) (q α)
                                                                    ∙ cong₂ (mapProc _ _) (funExt \ v → snoc-∘ f g a v) refl )))
               ∙ sym (bind-map (neg (image g) (image-fn _)) _ _)) ∙ cong₂ bind (sym (neg-image-∘ f' g' )) refl)
             ∙ sym (inps'-eq _ _ _ q)) )
@@ -234,7 +234,7 @@ mapProc-swap : ∀ {m} (P : Proc (suc (suc m)))
   → mapProc _ _ swap P ≡ Fold (mapP∞ (mapSProc' _ _ swap) (Unfold P))
 mapProc-swap P =
   cong Fold (mapProc'-eq' _ _ _ (Unfold P)
-            ∙ cong′ (bind (Unfold P))
+            ∙ congS (bind (Unfold P))
                 (funExt \ aq → inps-eq _ aq _ ∙ cong₂ _∪_ refl (inps'2-swap aq) ∙ unit _)
             ∙ sym (mapP∞-is-bind (Unfold P)))
 
@@ -488,8 +488,8 @@ module _ where
   !Proc-eq : ∀ {n} {P : Proc n}
     → !Proc P ≡ Fold (stepL (Unfold P) (!Proc P) ∪ stepL (synchF (Unfold P) (Unfold P)) (!Proc P))
   !Proc-eq {n} {P} =
-    cong′ (λ x → isPi-alg.!X (x n) P) (fix-eq ProcPi-algF) ∙ cong Fold (fix-eq d) ∙ cong Fold (cong₂ _∪_ (cong (stepL (Unfold P))
-          (sym (cong′ (λ x → isPi-alg.!X (x n) P) (fix-eq ProcPi-algF))))
-          (cong (stepL (synchF (Unfold P) (Unfold P))) (sym (cong′ (λ x → isPi-alg.!X (x n) P) (fix-eq ProcPi-algF)))))
+    congS (λ x → isPi-alg.!X (x n) P) (fix-eq ProcPi-algF) ∙ cong Fold (fix-eq d) ∙ cong Fold (cong₂ _∪_ (cong (stepL (Unfold P))
+          (sym (congS (λ x → isPi-alg.!X (x n) P) (fix-eq ProcPi-algF))))
+          (cong (stepL (synchF (Unfold P) (Unfold P))) (sym (congS (λ x → isPi-alg.!X (x n) P) (fix-eq ProcPi-algF)))))
     where
       d = λ !p → stepL' (Unfold P ∪ synchF (Unfold P) (Unfold P)) (λ α → Fold (!p α))

--- a/pi-calculus/semantics/Coalgebra.agda
+++ b/pi-calculus/semantics/Coalgebra.agda
@@ -140,14 +140,14 @@ module _ where
   bout∈stepν : ∀ {n} (ch : Name n) {P}
     → ⟨ `bout ch ((ν (mapPi swap P))) ∈ stepν (`bout (ι ch) (P)) ⟩
   bout∈stepν ch with canNu? (bout (ι ch))
-  bout∈stepν ch | bout p = ∣ StepPath refl (cong′ bout (ι-inj _ _ p)) refl ∣₁
+  bout∈stepν ch | bout p = ∣ StepPath refl (congS bout (ι-inj _ _ p)) refl ∣₁
   bout∈stepν ch | nope (bout x) = ⊥-rec (fresh-ι x)
 
   bout∈stepν2 : ∀ {n} (ch : Name n) {P}
     → ⟨ `bout ch (P) ∈ stepν (`out (ι ch) (fresh n) (P)) ⟩
   bout∈stepν2 ch  with canNu? (out (ι ch) (fresh _))
   bout∈stepν2 ch | out x x₁ = ⊥-rec (fresh-ι (sym x₁))
-  bout∈stepν2 ch | out2 p q = ∣ StepPath refl (cong′ bout (ι-inj _ _ p)) refl ∣₁
+  bout∈stepν2 ch | out2 p q = ∣ StepPath refl (congS bout (ι-inj _ _ p)) refl ∣₁
   bout∈stepν2 ch | nope (out x) = ⊥-rec (fresh-ι x)
 
   inp∈stepν : ∀ {n} (ch v : Name n) {P}
@@ -160,7 +160,7 @@ module _ where
   binp∈stepν : ∀ {n} (ch : Name n) {P}
     → ⟨ `binp ch ((ν (mapPi swap P))) ∈ stepν (`binp (ι ch) (P)) ⟩
   binp∈stepν ch with canNu? (binp (ι ch))
-  binp∈stepν ch | binp p = ∣ StepPath refl (cong′ binp (ι-inj _ _ p)) refl ∣₁
+  binp∈stepν ch | binp p = ∣ StepPath refl (congS binp (ι-inj _ _ p)) refl ∣₁
   binp∈stepν ch | nope (binp x) = ⊥-rec (fresh-ι x)
 
   out-ν-opsem : ∀ {n} (ch v : Name (suc n)) {aQ : Step Pi n} {P}
@@ -482,7 +482,7 @@ module _ (ih : ▹ ∀ {n} (P : Pi n) → Eval.eval _ P ≡  evalGM P .elem _ (�
   stepL'-step : ∀ {n} P Q
     → mapF' {n = n} (λ α m i x → eval m x) (SL.stepL' (step P) Q)
         ≡ SL'.stepL' (Unfold (eval n P)) (\ α → eval n (Q α))
-  stepL'-step P Q = stepL'-step-g (step P) Q ∙ (cong′ SL'.stepL' (sym (cong Unfold (fix-eq eval-fun <* _ <* P))) <* λ α → eval _ (Q α))
+  stepL'-step P Q = stepL'-step-g (step P) Q ∙ (congS SL'.stepL' (sym (cong Unfold (fix-eq eval-fun <* _ <* P))) <* λ α → eval _ (Q α))
 
   nu-par : ∀ {n} P Q 
     → eval-fun (next (fix eval-fun)) n (P ∣∣ Q)
@@ -521,7 +521,7 @@ module _ (ih : ▹ ∀ {n} (P : Pi n) → Eval.eval _ P ≡  evalGM P .elem _ (�
   evalGM-eq' {n} (! P) =
     (fix-eq eval-fun <* n <* (! P))
     ∙ cong Fold (cong₂ _∪_ (stepL'-step P _
-                            ∙ cong′ (SL'.stepL' (Unfold (eval _ P)))
+                            ∙ congS (SL'.stepL' (Unfold (eval _ P)))
                                     (later-ext \ α → ih α (! P)
                                                       ∙ cong !Proc (sym (ih α P))
                                                       ∙ (cong isPi-alg.!X (fix-eq ProcPi-algF <* _) <* eval n P)))
@@ -559,10 +559,10 @@ evalGM-eq P ρ =
 eval-≈ : ∀ {n} {P Q : Pi n} → P ≈ Q → Eval'.eval _ P ≡ Eval'.eval _ Q
 eval-≈ {n}{P}{Q} c =
   sym (Eval'.eval-eq' P)
-  ∙ cong′ (Eval.eval n) (sym (mapPi-id P))
+  ∙ congS (Eval.eval n) (sym (mapPi-id P))
   ∙ evalGM-eq P (λ x → x)
   ∙ (cong elem (evalX≈ PiMod-model c) <* _ <* (\ x → x))
   ∙ sym (evalGM-eq Q (λ x → x))
-  ∙ cong′ (Eval.eval n) (mapPi-id Q)
+  ∙ congS (Eval.eval n) (mapPi-id Q)
   ∙ Eval'.eval-eq' Q
 

--- a/pi-calculus/semantics/Coalgebra.agda
+++ b/pi-calculus/semantics/Coalgebra.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --guarded #-}
+{-# OPTIONS --cubical --guarded -WnoUnsupportedIndexedMatch #-}
 
 open import Cubical.Data.Sum hiding (inl; inr) 
 open import Cubical.Data.Empty renaming (rec to ⊥-rec)

--- a/pi-calculus/semantics/Dynamics.agda
+++ b/pi-calculus/semantics/Dynamics.agda
@@ -323,7 +323,7 @@ stepν-out-fresh : ∀ {m}{ch : Name m}{R : ▹ Proc (suc m)}
 stepν-out-fresh {m} {ch} {R} with decName (ι ch) (fresh _) | decName (fresh m) (fresh m)
 ... | yes p | _ = ⊥-rec (fresh-ι p)
 ... | no _  | no ¬r = ⊥-rec (¬r refl)
-... | no ¬p | yes r = cong η (StepPath refl (cong′ bout (down-ι ¬p)) refl)
+... | no ¬p | yes r = cong η (StepPath refl (congS bout (down-ι ¬p)) refl)
 
 ν-in-pr : ∀{m n}{a' : Label _ (suc n)}
     (prf : Σ (Label m _) (isLabelι a'))

--- a/pi-calculus/semantics/Dynamics.agda
+++ b/pi-calculus/semantics/Dynamics.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --guarded #-}
+{-# OPTIONS --cubical --guarded -WnoUnsupportedIndexedMatch #-}
 
 open import Cubical.Data.Sum hiding (inl; inr) 
 open import Cubical.Data.Empty renaming (rec to ⊥-rec)

--- a/pi-calculus/semantics/FullAbstraction.agda
+++ b/pi-calculus/semantics/FullAbstraction.agda
@@ -81,7 +81,7 @@ module Bisim-≡ where
                                                                                   (a , _) (step q) m'' in
                                                          transport (cong (λ x → ⟨ x ∈ mapF ((\ m _ x α → eval m x)) (step y) ⟩)
                                                                      ((λ i → (a , λ α → eq' α (~ i))) ∙ sym eq))
-                                                                     (transport (cong ⟨_⟩ (cong₂ _∈_ (cong′ (a ,_) (later-ext (λ α → sym (eval-≈ q'c) ∙ cong′ (eval _) (λ i → r (~ i) α))))
+                                                                     (transport (cong ⟨_⟩ (cong₂ _∈_ (congS (a ,_) (later-ext (λ α → sym (eval-≈ q'c) ∙ congS (eval _) (λ i → r (~ i) α))))
                                                                      (cong Unfold (sym (fix-eq eval-fun <* _ <* q) ∙ sym (eval-≈ qc) ∙ (fix-eq eval-fun <* _ <* y)))))  ∈stepy )
                                                 }) m''
 

--- a/pi-calculus/semantics/MapProcLemmata.agda
+++ b/pi-calculus/semantics/MapProcLemmata.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --guarded #-}
+{-# OPTIONS --cubical --guarded -WnoUnsupportedIndexedMatch #-}
 open import Cubical.Data.Sum hiding (inl; inr) renaming (rec to rec⊎)
 open import Cubical.Data.Empty renaming (rec to ⊥-rec)
 open import Cubical.Data.Nat

--- a/pi-calculus/semantics/MapProcLemmata.agda
+++ b/pi-calculus/semantics/MapProcLemmata.agda
@@ -37,7 +37,7 @@ end-map : ∀ {n m} (f : Name n → Name m) →
       mapProc n m f endProc ≡ endProc
 end-map {n}{m} f =
   cong Fold (mapProc'-eq' _ _ _ _
-            ∙ cong′ (mapProcF (next mapProc') _ _ f) (cong′ Unfold (cong (λ alg → isPi-alg.endX (alg n)) (fix-eq ProcPi-algF)))
+            ∙ congS (mapProcF (next mapProc') _ _ f) (congS Unfold (cong (λ alg → isPi-alg.endX (alg n)) (fix-eq ProcPi-algF)))
               ∙ sym (cong Unfold (cong (λ alg → isPi-alg.endX (alg m)) (fix-eq ProcPi-algF))))
 
 -- mapProc and sumProc.
@@ -45,9 +45,9 @@ sum-map : ∀ {n m} (f : Name n → Name m) P Q →
   mapProc n m f (sumProc P Q) ≡ sumProc (mapProc n m f P) (mapProc n m f Q)
 sum-map {n}{m} f P Q =
   cong Fold (mapProc'-eq' _ _ _ _
-            ∙ cong′ (mapProcF (next mapProc') _ _ f) (cong′ Unfold (cong (λ alg → isPi-alg.sumX (alg n) P Q) (fix-eq ProcPi-algF)))
+            ∙ congS (mapProcF (next mapProc') _ _ f) (congS Unfold (cong (λ alg → isPi-alg.sumX (alg n) P Q) (fix-eq ProcPi-algF)))
             ∙ cong₂ _∪_ (sym (mapProc'-eq' _ _ _ _)) (sym (mapProc'-eq' _ _ _ _))
-            ∙ sym (cong′ Unfold (cong (λ alg → isPi-alg.sumX (alg m) (mapProc _ _ f P) (mapProc _ _ f Q)) (fix-eq ProcPi-algF))))
+            ∙ sym (congS Unfold (cong (λ alg → isPi-alg.sumX (alg m) (mapProc _ _ f P) (mapProc _ _ f Q)) (fix-eq ProcPi-algF))))
 
 -- mapProc and guardProc.
 
@@ -64,10 +64,10 @@ guard-map : ∀ {n m} (f : Inj n m) x y P →
   mapProc n m (fst f) (guardProc x y P) ≡ guardProc (fst f x) (fst f y) (mapProc n m (fst f) P)
 guard-map {n}{m} f x y P =
   cong Fold (mapProc'-eq' _ _ _ _
-            ∙ cong′ (mapProcF (next mapProc') _ _ (fst f)) (cong′ Unfold (cong (λ alg → isPi-alg.guardX (alg n) x y P) (fix-eq ProcPi-algF)))
+            ∙ congS (mapProcF (next mapProc') _ _ (fst f)) (congS Unfold (cong (λ alg → isPi-alg.guardX (alg n) x y P) (fix-eq ProcPi-algF)))
             ∙ guard-map' f x y P
-            ∙ cong′ (stepguard _ _) (sym (mapProc'-eq' _ _ _ _))
-            ∙ sym (cong′ Unfold (cong (λ alg → isPi-alg.guardX (alg m) (fst f x) (fst f y) (mapProc _ _ (fst f) P)) (fix-eq ProcPi-algF))))
+            ∙ congS (stepguard _ _) (sym (mapProc'-eq' _ _ _ _))
+            ∙ sym (congS Unfold (cong (λ alg → isPi-alg.guardX (alg m) (fst f x) (fst f y) (mapProc _ _ (fst f) P)) (fix-eq ProcPi-algF))))
 
 -- mapProc and νProc (which requires some extra lemmata).
 no-stepν-inp : ∀ {n} v P → stepν (`inp (fresh n) v P) ≡ ø
@@ -78,7 +78,7 @@ no-stepν-inp v P | nope x = refl
 stepν-inp : ∀ {n} ch v P → stepν {n} (`inp (ι ch) (ι v) P) ≡ η (`inp ch v λ α → νProc (P α) )
 stepν-inp ch v P with canNu? (inp (ι ch) (ι v))
 stepν-inp ch v P | inp {ch = ch'}{v'} x x₁ =
-  cong′ η (StepPath refl (sym λ i → inp (ι-inj ch ch' x i) (ι-inj v v' x₁ i)) refl)
+  congS η (StepPath refl (sym λ i → inp (ι-inj ch ch' x i) (ι-inj v v' x₁ i)) refl)
 stepν-inp ch v P | nope (inp (_⊎_.inl x)) = ⊥-rec (fresh-ι (x))
 stepν-inp ch v P | nope (inp (_⊎_.inr x)) = ⊥-rec (fresh-ι (x))
 
@@ -86,7 +86,7 @@ stepν-out : ∀ {n} ch v P → stepν {n} (`out (ι ch) (ι v) P) ≡ η (`out 
 stepν-out ch v P with canNu? (out (ι ch) (ι v))
 stepν-out ch v P | out2 x x₁ = ⊥-rec (fresh-ι (x₁))
 stepν-out ch v P | out {ch = ch'}{v'} x x₁ =
-  cong′ η (StepPath refl (sym (λ i → out (ι-inj _ ch' x i) (ι-inj _ v' x₁ i))) refl)
+  congS η (StepPath refl (sym (λ i → out (ι-inj _ ch' x i) (ι-inj _ v' x₁ i))) refl)
 stepν-out ch v P | nope (out x) = ⊥-rec (fresh-ι (x))
 
 stepν-bout : ∀ {n} {P : ▹ Proc _} {ch : Name n}
@@ -116,10 +116,10 @@ abstract
   no-stepνF-inps' : ∀ {n m} (f : Name n → Name m) P
     → stepνF (inps' (\ _ → mapProc') (lift f) (fresh n) P) ≡ ø
   no-stepνF-inps' f P =
-    cong′ stepνF (inps'-eq (\ _ → mapProc') _ _ _)
+    congS stepνF (inps'-eq (\ _ → mapProc') _ _ _)
     ∙ bind-bind (neg (image (lift f)) (image-fn _)) _ _
     ∙ cong (bind (neg (image (lift f)) (image-fn _)))
-        (funExt λ v → cong′ stepν (StepPath refl (cong′ (λ x → inp x v) (lift-fresh f)) refl) ∙ no-stepν-inp v _)
+        (funExt λ v → congS stepν (StepPath refl (congS (λ x → inp x v) (lift-fresh f)) refl) ∙ no-stepν-inp v _)
     ∙ bind-ø (neg (image (lift f)) (image-fn _))
 
   stepνF-inps' : ∀ {n m} ch (f : Inj n m) P →
@@ -128,14 +128,14 @@ abstract
     stepνF (inps' (\ _ → mapProc') (lift (fst f)) (ι ch) P) ≡
       inps' (λ _ → mapProc') (fst f) ch (λ α → νProc (mapProc _ _ swap (P α)))
   stepνF-inps' ch f P ih =
-    cong′ stepνF (inps'-eq (\ _ → mapProc') _ _ _)
+    congS stepνF (inps'-eq (\ _ → mapProc') _ _ _)
     ∙ bind-bind (neg (image (lift (fst f))) (image-fn _)) _ _
     ∙ cong₂ bind (neg-image-lift (fst f)) refl
     ∙ bind-map (neg (image (fst f)) (image-fn _)) _ _
     ∙ cong-bind (neg (image (fst f)) (image-fn _)) (λ z m →
-        cong′ stepν (StepPath refl (cong′ (λ x → inp x (ι z)) (lift-ι (fst f) ch)) refl)
+        congS stepν (StepPath refl (congS (λ x → inp x (ι z)) (lift-ι (fst f) ch)) refl)
         ∙ stepν-inp (fst f ch) z _
-        ∙ cong η (cong′ (`inp (fst f ch) z) (later-ext (λ α → cong νProc (cong′ (λ y → mapProc _ _ y (P α)) (funExt (snoc-lift-ι (fst f) z))
+        ∙ cong η (congS (`inp (fst f ch) z) (later-ext (λ α → cong νProc (congS (λ y → mapProc _ _ y (P α)) (funExt (snoc-lift-ι (fst f) z))
                                                                          ∙ sym (mapmapProc _ _ _ (_ , lift-inj (_ , snoc-inj f z m)) (_ , swap-inj) _))
                                                                 ∙ sym (ih α _ _ (_ , snoc-inj f z m) (mapProc _ _ swap (P α)))))))
     ∙ sym (inps'-eq (\ _ → mapProc') _ _ _)
@@ -179,7 +179,7 @@ abstract
 ... | yes q | q' = ⊥-rec (fresh-ι (sym p))
 ... | no q | yes q' =
   cong η (StepPath refl
-                   (cong′ bout (ι-inj _ _ (cong ι (cong (fst f) (sym lem)) ∙ p)))
+                   (congS bout (ι-inj _ _ (cong ι (cong (fst f) (sym lem)) ∙ p)))
                    (later-ext (λ _ → refl)))
   where                   
     lem : down _ q ≡ ch'
@@ -204,10 +204,10 @@ abstract
 ... | yes q = ⊥-rec (fresh-ι (sym p))
 ... | no q =
   cong η (StepPath refl
-                   (cong′ bout (ι-inj _ _ (cong ι (cong (fst f) (sym lem)) ∙ p)))
+                   (congS bout (ι-inj _ _ (cong ι (cong (fst f) (sym lem)) ∙ p)))
     (later-ext (λ α → ih α _ _ (lift (fst f) , lift-inj f) (mapProc (suc (suc n)) (suc (suc n)) swap (P α))
-                      ∙ cong′ νProc (mapmapProc _ _ _ (_ , lift-inj (_ , lift-inj f)) (_ , swap-inj) (P α)
-                                  ∙ cong′ (λ g → mapProc _ _ g (P α)) (funExt (swap-lift (fst f)))
+                      ∙ congS νProc (mapmapProc _ _ _ (_ , lift-inj (_ , lift-inj f)) (_ , swap-inj) (P α)
+                                  ∙ congS (λ g → mapProc _ _ g (P α)) (funExt (swap-lift (fst f)))
                                   ∙ sym (mapmapProc _ _ _ (_ , swap-inj) (_ , lift-inj (_ , lift-inj f)) (P α))))))
   where                   
     lem : down _ q ≡ ch'
@@ -256,10 +256,10 @@ abstract
 ... | yes q = ⊥-rec (fresh-ι (sym p))
 ... | no q =
   cong₂ _∪_ (cong η (StepPath refl
-                              (cong′ binp (ι-inj _ _ (cong ι (cong (fst f) (sym lem)) ∙ p)))
+                              (congS binp (ι-inj _ _ (cong ι (cong (fst f) (sym lem)) ∙ p)))
               (later-ext (λ α →  ih α _ _ (lift (fst f) , lift-inj f) (mapProc (suc (suc n)) (suc (suc n)) swap (P α))
-                                 ∙ cong′ νProc (mapmapProc _ _ _ (_ , lift-inj (_ , lift-inj f)) (_ , swap-inj) (P α)
-                                            ∙ cong′ (λ g → mapProc _ _ g (P α)) (funExt (swap-lift (fst f)))
+                                 ∙ congS νProc (mapmapProc _ _ _ (_ , lift-inj (_ , lift-inj f)) (_ , swap-inj) (P α)
+                                            ∙ congS (λ g → mapProc _ _ g (P α)) (funExt (swap-lift (fst f)))
                                             ∙ sym (mapmapProc _ _ _ (_ , swap-inj) (_ , lift-inj (_ , lift-inj f)) (P α)))))))
             (sym ((λ i → stepνF (inps' (λ _ → mapProc') (lift (fst f)) (r i) P)) ∙ stepνF-inps' _ f P ih))
   where                   
@@ -282,7 +282,7 @@ abstract
 
 ν-map : ∀ n m (f : Inj n m) p
   → mapProc _ _ (fst f) (νProc p) ≡ νProc (mapProc _ _ (lift (fst f)) p)
-ν-map = fix (\ ih n m f p → cong Fold (mapProc'-eq' _ _ (fst f) (Unfold (νProc p))) ∙ cong′ (\ p → Fold (mapProcF (next mapProc') _ _ (fst f) (Unfold p)))
+ν-map = fix (\ ih n m f p → cong Fold (mapProc'-eq' _ _ (fst f) (Unfold (νProc p))) ∙ congS (\ p → Fold (mapProcF (next mapProc') _ _ (fst f) (Unfold p)))
       (cong (λ alg₁ → isPi-alg.νX (alg₁ n) p) (fix-eq ProcPi-algF)) ∙ cong Fold (bind-bind (Unfold p) _ _ )
       ∙ cong Fold (cong₂ bind (\ _ → Unfold p) (funExt \ v → ν-mapF n m f v ih))
       ∙ sym (cong Fold (bind-bind (Unfold p) _ _))
@@ -332,7 +332,7 @@ stepL-map : (ih : ▹
        parProc (mapProc n₁ m₁ (fst f₁) p₁) (mapProc n₁ m₁ (fst f₁) q₁)))
       → ∀ n m (f : Inj n m) p q → mapProc' n m (fst f) (stepL (Unfold p) q) ≡ stepL (Unfold (mapProc _ _ (fst f) p)) (mapProc _ _ (fst f) q)
 stepL-map ih n m f p q = mapProc'-eq' _ _ _ (stepL (Unfold p) q) ∙ (bind-map (Unfold p) _ _
-                       ∙ cong′ (bind (Unfold p))
+                       ∙ congS (bind (Unfold p))
                           (funExt \ v → inps-eq (fst f) (mapStep (λ m₁ i x α → parProc (x α) (mapProc n m₁ (fst i) q)) v) _
                           ∙ cong₂ _∪_ (cong η (StepPath refl refl (later-ext \ α → ih α _ _ (labelRen (theLabel v) m (fst f) , labelRen-inj _ _ f) _ _ ∙
                                                                   cong₂ parProc refl (mapmapProc _ _ _ (_ , labelRen-inj (theLabel v) m f) (labelInj (theLabel v)) q
@@ -347,7 +347,7 @@ stepL-map ih n m f p q = mapProc'-eq' _ _ _ (stepL (Unfold p) q) ∙ (bind-map (
     inps-lemma (b , Q') with binp? b
     inps-lemma (.(binp _) , Q') | binp {ch} = inps'-eq (\ _ → mapProc') (fst f) _ _
                                          ∙  cong-bind (neg (image (fst f)) (image-fn _)) (\ v mv →
-                                             cong′ η ( cong′ (`inp (fst f ch) v) (later-ext \ α →  ih α _ _ (snoc (fst f) v , snoc-inj f v mv) _ _ ∙ cong₂ parProc refl
+                                             congS η ( congS (`inp (fst f ch) v) (later-ext \ α →  ih α _ _ (snoc (fst f) v , snoc-inj f v mv) _ _ ∙ cong₂ parProc refl
                                                  (mapmapProc _ _ _ (_ , snoc-inj f v mv) (_ , ι-inj) q ∙ cong₂ (mapProc _ _) (funExt \ v → snoc-ι _ _ v) refl ∙
                                                    sym (mapmapProc _ _ _ (_ , \ _ _ p → p) f q))  ) )  )
                                          ∙ sym (map-bind (neg (image (fst f)) (image-fn _)) _ _)
@@ -360,7 +360,7 @@ stepR-map : (ih : ▹
        parProc (mapProc n₁ m₁ (fst f₁) p₁) (mapProc n₁ m₁ (fst f₁) q₁)))
       → ∀ n m (f : Inj n m) p q → mapProc' n m (fst f) (stepR p (Unfold q)) ≡ stepR (mapProc _ _ (fst f) p) (Unfold (mapProc _ _ (fst f) q))
 stepR-map ih n m f p q = mapProc'-eq' _ _ _ (stepR p (Unfold q)) ∙ (bind-map (Unfold q) _ _
-                       ∙ cong′ (bind (Unfold q))
+                       ∙ congS (bind (Unfold q))
                           ( (funExt \ v → inps-eq (fst f) (mapStep (λ m₁ i x α → parProc (mapProc n m₁ (fst i) p) (x α)) v) _
                           ∙ cong₂ _∪_ (cong η (StepPath refl refl (later-ext \ α → ih α _ _ (labelRen (theLabel v) m (fst f) , labelRen-inj _ _ f) _ _ ∙
                                                                   cong₂ parProc (mapmapProc _ _ _ (_ , labelRen-inj _ _ f) (labelInj (theLabel v)) p
@@ -375,7 +375,7 @@ stepR-map ih n m f p q = mapProc'-eq' _ _ _ (stepR p (Unfold q)) ∙ (bind-map (
     inps-lemma (b , Q') with binp? b
     inps-lemma (.(binp _) , Q') | binp {ch} =  inps'-eq (\ _ → mapProc') (fst f) _ _
                                          ∙  cong-bind (neg (image (fst f)) (image-fn _)) (\ v mv →
-                                             cong′ η ( cong′ (`inp (fst f ch) v) (later-ext \ α →  ih α _ _ (snoc (fst f) v , snoc-inj f v mv) _ _
+                                             congS η ( congS (`inp (fst f ch) v) (later-ext \ α →  ih α _ _ (snoc (fst f) v , snoc-inj f v mv) _ _
                                               ∙ cong₂ parProc
                                                  (mapmapProc _ _ _ (_ , snoc-inj f v mv) (_ , ι-inj) p
                                                    ∙ cong₂ (mapProc _ _) (funExt \ v → snoc-ι _ _ v) refl ∙ sym (mapmapProc _ _ _ (_ , \ _ _ p → p) f p)) refl  ) )  )
@@ -392,7 +392,7 @@ synch'-map n m f (`out x x₁ P) (`out x₂ x₃ Q) parX ih = refl
 synch'-map n m f (`out x x₁ P) (`bout x₂ Q) parX ih = refl
 synch'-map n m f (`out ch z P) (`inp ch' z' Q) parX ih with decName ch ch' | decName z z'
 synch'-map n m f (`out ch z P) (`inp ch' z' Q) parX ih | yes p | yes p₁ = sym (synch'-out-inp _ _ _ _ (cong (fst f) p) (cong (fst f) p₁)
-  ∙ cong′ η (cong′ `τ (later-ext \ α → sym (ih α _ _ f _ _))))
+  ∙ congS η (congS `τ (later-ext \ α → sym (ih α _ _ f _ _))))
 synch'-map n m f (`out ch z P) (`inp ch' z' Q) parX ih | yes p | no ¬p = sym (no-synch'-out-inp _ _ _ _ \ _ ze → ¬p (f .snd _ _ ze))
 synch'-map n m f (`out ch z P) (`inp ch' z' Q) parX ih | no ¬p | q
   = sym (no-synch'-out-inp _ _ _ _ (\ che ze → ¬p (f .snd _ _ che)))
@@ -406,7 +406,7 @@ synch'-map n m f (`bout x P) (`bout x₁ Q) parX ih = refl
 synch'-map n m f (`bout x P) (`inp x₁ x₂ Q) parX ih = refl
 synch'-map n m f (`bout ch P) (`binp ch' Q) parX ih with decName ch ch'
 synch'-map n m f (`bout ch P) (`binp ch' Q) parX ih | yes p = 
-  (cong′ η (cong′ `τ (later-ext \ α → ν-map _ _ f _ ∙ cong νProc (ih α _ _ (_ , lift-inj f) _ _)))
+  (congS η (congS `τ (later-ext \ α → ν-map _ _ f _ ∙ cong νProc (ih α _ _ (_ , lift-inj f) _ _)))
   ∙ sym (unit _)) ∙ cong₂ _∪_ (sym (synch'-bout-binp _ _ _ _ (cong (fst f) p))) ((sym (cong₂ bind (inps'-eq _ _ _ Q) refl
           ∙ bind-bind (neg (image (fst f)) (image-fn _)) _ _
           ∙ bind-ø (neg (image (fst f)) (image-fn _)))))
@@ -438,7 +438,7 @@ synch'-map n m f (`binp x P) (`inp x₁ x₂ Q) parX ih = sym (idem _)
 synch'-map n m f (`binp x P) (`binp x₁ Q) parX ih = sym (cong₂ _∪_ (idem _) refl ∙ idem _) ∙ cong₂ _∪_ (cong₂ _∪_ refl ((sym (cong₂ bind (inps'-eq _ _ _ Q) refl
           ∙ bind-bind (neg (image (fst f)) (image-fn _)) _ _
           ∙ bind-ø (neg (image (fst f)) (image-fn _)))))) (sym (cong₂ bind (inps'-eq _ _ _ P) refl ∙ bind-bind (neg (image (fst f)) (image-fn _)) _ _
-                                              ∙ cong′ (bind (neg (image (fst f)) (image-fn _))) (funExt \ z →  cong₂ _∪_ refl (cong₂ bind (inps'-eq _ _ _ Q) refl
+                                              ∙ congS (bind (neg (image (fst f)) (image-fn _))) (funExt \ z →  cong₂ _∪_ refl (cong₂ bind (inps'-eq _ _ _ Q) refl
           ∙ bind-bind (neg (image (fst f)) (image-fn _)) _ _
           ∙ bind-ø (neg (image (fst f)) (image-fn _))) ∙ idem _) ∙ bind-ø (neg (image (fst f)) (image-fn _))))
 synch'-map n m f (`binp x P) (`τ Q) parX ih = sym (idem _)
@@ -457,7 +457,7 @@ synch'-map n m f (`τ P) (`τ Q) parX  ih = refl
 
 synchF-eq : ∀ {n} (p q : F' n (\ _ → Proc))
   → synchF p q ≡ synchF' (λ _ → parProc) (λ _ → νProc) p q ∪ synchF' (next (λ x y → parProc y x)) (λ _ → νProc) q p
-synchF-eq p q = cong′ (bind p) (funExt (λ _ → bind-∪ _ _ q)) ∙ bind-∪ _ _ p ∙ cong₂ _∪_ refl (bind-comm _ p q)
+synchF-eq p q = congS (bind p) (funExt (λ _ → bind-∪ _ _ q)) ∙ bind-∪ _ _ p ∙ cong₂ _∪_ refl (bind-comm _ p q)
 
 synch-map :
    (ih : ▹ (∀ n m (f : Inj n m) p q → mapProc n m (fst f) (parProc p q) ≡ parProc (mapProc _ _ (fst f) p) (mapProc _ _ (fst f) q))) →
@@ -474,11 +474,11 @@ synchF-map :
 synchF-map ih n m f v v' =
   mapProc'-eq' _ _ _ _
     ∙ bind-bind v _ _
-    ∙ cong′ (bind v) (funExt (λ x →
+    ∙ congS (bind v) (funExt (λ x →
         bind-bind v' _ _
-        ∙ cong′ (bind v') (funExt (λ y → synch-map ih n m f x y))
+        ∙ congS (bind v') (funExt (λ y → synch-map ih n m f x y))
         ∙ bind-comm _ v' (inps (next mapProc') (fst f) x  _)
-        ∙ cong′ (bind (inps (next mapProc') (fst f) x  _)) (funExt (λ y → sym (bind-bind v' _ _)))))
+        ∙ congS (bind (inps (next mapProc') (fst f) x  _)) (funExt (λ y → sym (bind-bind v' _ _)))))
     ∙ sym (bind-bind v _ _)
     ∙ sym (cong₂ synchF (mapProc'-eq' _ _ _ _) (mapProc'-eq' _ _ _ _))
 
@@ -486,12 +486,12 @@ par-map : ∀ n m (f : Inj n m) P Q →
   mapProc n m (fst f) (parProc P Q) ≡ parProc (mapProc _ _ (fst f) P) (mapProc _ _ (fst f) Q)
 par-map = fix \ ih n m f P Q →
   cong Fold (mapProc'-eq' _ _ _ _
-            ∙ cong′ (mapProcF (next mapProc') _ _ (fst f)) (cong′ Unfold (cong (λ alg → isPi-alg.parX (alg n) P Q) (fix-eq ProcPi-algF)))
+            ∙ congS (mapProcF (next mapProc') _ _ (fst f)) (congS Unfold (cong (λ alg → isPi-alg.parX (alg n) P Q) (fix-eq ProcPi-algF)))
             ∙ cong₂ _∪_ (cong₂ _∪_
                 (sym (mapProc'-eq' _ _ _ _) ∙ stepL-map ih _ _ f P Q) 
                 (sym (mapProc'-eq' _ _ _ _) ∙ stepR-map ih _ _ f P Q))
                 (sym (mapProc'-eq' _ _ _ _) ∙ synchF-map ih _ _ f (Unfold P) (Unfold Q))
-            ∙ sym (cong′ Unfold (cong (λ alg → isPi-alg.parX (alg _) (mapProc _ _ (fst f) P) (mapProc _ _ (fst f) Q)) (fix-eq ProcPi-algF))))
+            ∙ sym (congS Unfold (cong (λ alg → isPi-alg.parX (alg _) (mapProc _ _ (fst f) P) (mapProc _ _ (fst f) Q)) (fix-eq ProcPi-algF))))
 
 -- mapProc and !Proc.
 
@@ -503,11 +503,11 @@ stepL-map' = stepL-map (next par-map) _ _
 rep-map : ∀ {n m} (f : Inj n m) (P : Proc n) →
   mapProc n m (fst f) (!Proc P) ≡ !Proc (mapProc _ _ (fst f) P) 
 rep-map = fix λ ih f P →
-  cong′ (mapProc _ _ (fst f)) (!Proc-eq {P = P})
+  congS (mapProc _ _ (fst f)) (!Proc-eq {P = P})
   ∙ cong Fold
       (∪-map (fst f) _ _
       ∙ cong₂ _∪_ (stepL-map (next par-map) _ _ f P (!Proc P)
-                  ∙ cong′ (stepL' (Unfold (mapProc _ _ (fst f) P))) (later-ext (λ α → ih α f P)))
+                  ∙ congS (stepL' (Unfold (mapProc _ _ (fst f) P))) (later-ext (λ α → ih α f P)))
                   (stepL-map (next par-map) _ _ f (Fold (synchF (Unfold P) (Unfold P))) (!Proc P)
                   ∙ cong₂ stepL' (synchF-map (next par-map) _ _ f (Unfold P) (Unfold P)) (later-ext (λ α → ih α f P))))
   ∙ sym (!Proc-eq {P = mapProc _ _ (fst f) P})
@@ -517,8 +517,8 @@ rep-map = fix λ ih f P →
 --   mapProc _ _ f (actProc a P) ≡ actProc (mapAct f a) (mapProc _ _ f P)
 -- act-map {n}{m} f a P = 
 --   cong Fold (mapProc'-eq' _ _ _ _
---             ∙ cong′ (mapProcF (next mapProc') _ _ f) (cong′ Unfold (cong (λ alg → isCCS-alg.actX (alg n) a P) (fix-eq ProcCCS-algF)))
---             ∙ sym (cong′ Unfold (cong (λ alg → isCCS-alg.actX (alg m) (mapAct f a) (mapProc _ _ f P)) (fix-eq ProcCCS-algF))))
+--             ∙ congS (mapProcF (next mapProc') _ _ f) (congS Unfold (cong (λ alg → isCCS-alg.actX (alg n) a P) (fix-eq ProcCCS-algF)))
+--             ∙ sym (congS Unfold (cong (λ alg → isCCS-alg.actX (alg m) (mapAct f a) (mapProc _ _ f P)) (fix-eq ProcCCS-algF))))
 
 -- -- The main result of this file: evaluation into Proc respects actions
 -- -- on injective renamings.
@@ -536,10 +536,10 @@ rep-map = fix λ ih f P →
 --   cong₂ parProc (mapProc-evalX f p) (mapProc-evalX f q)
 --   ∙ sym (par-map _ _ f _ _)
 -- mapProc-evalX f (ν p) =
---   cong′ νProc (mapProc-evalX (lift (fst f) , lift-inj f) p)
+--   congS νProc (mapProc-evalX (lift (fst f) , lift-inj f) p)
 --   ∙ sym (ν-map _ _ (fst f) _)
 -- mapProc-evalX f (! p) =
---   cong′ !Proc (mapProc-evalX f p)
+--   congS !Proc (mapProc-evalX f p)
 --   ∙ sym (rep-map f _)
 
 -- mapProc-evalX : ∀ {n m} (f : Name m → Name n) (p : Pi m) →
@@ -556,8 +556,8 @@ rep-map = fix λ ih f P →
 --   cong₂ parProc (mapProc-evalX f p) (mapProc-evalX f q)
 --   ∙ sym (par-map _ _ {!!} _ _)
 -- mapProc-evalX f (ν p) =
---   cong′ νProc (mapProc-evalX (lift f) p)
+--   congS νProc (mapProc-evalX (lift f) p)
 --   ∙ sym (ν-map _ _ {!!} _)
 -- mapProc-evalX f (! p) =
---   cong′ !Proc (mapProc-evalX f p)
+--   congS !Proc (mapProc-evalX f p)
 --   ∙ sym (rep-map {!!} _)

--- a/pi-calculus/semantics/Model.agda
+++ b/pi-calculus/semantics/Model.agda
@@ -102,7 +102,7 @@ parPiMod p q .elem-nat f ρ = par-map _ _ f _ _ ∙ cong₂ parProc (p .elem-nat
 
 guardPiMod : ∀ {n} (x y : Name n) → PiMod n → PiMod n
 guardPiMod a b p .elem m g = guardProc (g a) (g b) (p .elem m g)
-guardPiMod a b p .elem-nat f ρ = guard-map f (ρ a) (ρ b) (p. elem _ ρ) ∙ cong′ (guardProc _ _) (p .elem-nat f ρ)
+guardPiMod a b p .elem-nat f ρ = guard-map f (ρ a) (ρ b) (p. elem _ ρ) ∙ congS (guardProc _ _) (p .elem-nat f ρ)
 
 PiMod-alg : ∀ n → isPi-alg PiMod n
 PiMod-alg n = record
@@ -232,7 +232,7 @@ mapPiMod-eval f end m' g = refl
 mapPiMod-eval f (out ch x · p) m' g =
   cong Fold (cong η (StepPath refl refl (later-ext \ α → mapPiMod-eval f p m' g)))
 mapPiMod-eval f (inp ch · p) m' g =
-  cong Fold (cong₂ _∪_ (cong′ (bind enum) (funExt \ v → cong η (StepPath refl refl (later-ext
+  cong Fold (cong₂ _∪_ (congS (bind enum) (funExt \ v → cong η (StepPath refl refl (later-ext
     \ α → mapPiMod-eval (lift f) p _ _ ∙ cong (evalX PiMod-alg p .elem _) ((funExt \ v' → cong (snoc g v) (lift-snoc _ _)
                                                                           ∙ f-snoc (snoc _ _) _ ∙ cong (\ f → f v') (cong₂ snoc (funExt \ v' → snoc-ι _ _ _)
                                                                            (snoc-fresh _ _))))))))

--- a/pi-calculus/semantics/StructuralCongruence.agda
+++ b/pi-calculus/semantics/StructuralCongruence.agda
@@ -50,12 +50,12 @@ module _ (ih : ▹ StructCong ProcPi-alg (mapProc _ _) _≡_) where
 -- Unitality of parProc.
   unit-par : ∀ {n} {P : Proc n} → parProc P endProc ≡ P
   unit-par {n}{P} =
-    cong′ (λ x → isPi-alg.parX (x n) P (isPi-alg.endX (x n))) (fix-eq ProcPi-algF)
+    congS (λ x → isPi-alg.parX (x n) P (isPi-alg.endX (x n))) (fix-eq ProcPi-algF)
     ∙ cong Fold (cong₂ _∪_ (unit _) (bind-ø (Unfold P))
                 ∙ unit _
-                ∙ cong′ (λ x → mapP∞ x (Unfold P))
+                ∙ congS (λ x → mapP∞ x (Unfold P))
                         (funExt (λ _ → StepPath refl refl
-                                                (later-ext (λ α → cong₂ parProc refl (cong′ Fold (mapProc'-eq' _ _ _ _))
+                                                (later-ext (λ α → cong₂ parProc refl (congS Fold (mapProc'-eq' _ _ _ _))
                                                  ∙ ih α .unit∣∣X ))))
                 ∙ mapidP∞ _)
 
@@ -77,19 +77,19 @@ module _ (ih : ▹ StructCong ProcPi-alg (mapProc _ _) _≡_) where
 
   comm-par : ∀ {n} {p q : Proc n} → parProc p q ≡ parProc q p
   comm-par {n}{P}{Q} =
-    cong′ (λ x → isPi-alg.parX (x n) P Q) (fix-eq ProcPi-algF)
+    congS (λ x → isPi-alg.parX (x n) P Q) (fix-eq ProcPi-algF)
     ∙ cong Fold (cong₂ _∪_ ((cong₂ _∪_
-        (cong′ (λ f → mapP∞ f (Unfold P)) (funExt (λ x → StepPath refl refl (later-ext (λ α → ih α .comm∣∣X {_}{_}{mapProc _ _ (fst (labelInj (theLabel x))) Q})))))
-        (cong′ (λ f → mapP∞ f (Unfold Q)) (funExt (λ x → StepPath refl refl (later-ext (λ α → ih α .comm∣∣X {_}{mapProc _ _ (fst (labelInj (theLabel x))) P})))))) ∙ comm _ _)
+        (congS (λ f → mapP∞ f (Unfold P)) (funExt (λ x → StepPath refl refl (later-ext (λ α → ih α .comm∣∣X {_}{_}{mapProc _ _ (fst (labelInj (theLabel x))) Q})))))
+        (congS (λ f → mapP∞ f (Unfold Q)) (funExt (λ x → StepPath refl refl (later-ext (λ α → ih α .comm∣∣X {_}{mapProc _ _ (fst (labelInj (theLabel x))) P})))))) ∙ comm _ _)
         (comm-synchF {_}{Unfold P}{Unfold Q}))
-    ∙ cong′ (λ x → isPi-alg.parX (x n) Q P) (sym (fix-eq ProcPi-algF))
+    ∙ congS (λ x → isPi-alg.parX (x n) Q P) (sym (fix-eq ProcPi-algF))
 
 -- Associativity of parProc (which requires many lemmata)..
   step-LR : ∀ {n} P Q R →
     stepL {n} (stepR P Q) R ≡ stepR P (stepL Q R)
   step-LR P Q R =
     mapmapP∞ _ _ Q
-    ∙ cong′ (λ f → mapP∞ f Q) (funExt (λ { (a , P') →
+    ∙ congS (λ f → mapP∞ f Q) (funExt (λ { (a , P') →
         StepPath refl refl (later-ext (λ α → ih α .assoc∣∣X {P = Fold (mapProc' _ _ _ _)}))}))
           ∙ sym (mapmapP∞ _ _ Q)
 
@@ -97,7 +97,7 @@ module _ (ih : ▹ StructCong ProcPi-alg (mapProc _ _) _≡_) where
     stepR {n} P (stepR Q R) ≡ stepR (parProc P Q) R
   step-RR P Q R =
     mapmapP∞ _ _ R
-    ∙ sym (cong′ (λ f → mapP∞ f R) (funExt (λ { (a , R') →
+    ∙ sym (congS (λ f → mapP∞ f R) (funExt (λ { (a , R') →
         StepPath refl refl (later-ext (λ α → cong₂ parProc (par-map _ _ (labelInj a) _ _) refl
           ∙ ih α .assoc∣∣X {P = Fold (mapProc' _ _ _ _)}))})))
 
@@ -109,7 +109,7 @@ module _ (ih : ▹ StructCong ProcPi-alg (mapProc _ _) _≡_) where
     cong η (StepPath refl refl (later-ext (λ α → ih α .assoc∣∣X {P = P' α})))
   stepL-synch'-L (.(bout _) , P') (.(binp _) , Q') R | bound refl' =
     cong η (StepPath refl refl (later-ext (λ α → cong₂ parProc refl (mapProc-id _ _)
-      ∙ sym (ih α .ν∣∣X) ∙ cong′ νProc (ih α .assoc∣∣X {P = P' α}{Q' α}))))
+      ∙ sym (ih α .ν∣∣X) ∙ congS νProc (ih α .assoc∣∣X {P = P' α}{Q' α}))))
   stepL-synch'-L (a , _) (b , _) R | nope = refl
 
   stepL-synch'-R : ∀ {n} (aP aQ : Step (\ n → ▹ Proc n) n) R →
@@ -121,7 +121,7 @@ module _ (ih : ▹ StructCong ProcPi-alg (mapProc _ _) _≡_) where
   stepL-synch'-R (.(bout _) , P) (.(binp _) , Q) R | bound refl' =
     cong η (StepPath refl refl (later-ext (λ α → cong₂ parProc refl (mapProc-id _ _)
             ∙ sym (ih α .ν∣∣X)
-            ∙ cong′ νProc (ih α .assoc∣∣X {P = Q α}{P α}))))
+            ∙ congS νProc (ih α .assoc∣∣X {P = Q α}{P α}))))
   stepL-synch'-R (a , P) (b , Q) R | nope = refl
 
   stepR-synch'-L : ∀ {n} P (aQ aR : Step (\ n → ▹ Proc n) n) →
@@ -135,7 +135,7 @@ module _ (ih : ▹ StructCong ProcPi-alg (mapProc _ _) _≡_) where
                     cong₂ parProc (mapProc-id _ _) refl
                     ∙ ih α .comm∣∣X {P = R}
                     ∙ sym (ih α .ν∣∣X)
-                    ∙ cong′ νProc (ih α .comm∣∣X {Q = Fold (mapProc' _ _ _ _)}
+                    ∙ congS νProc (ih α .comm∣∣X {Q = Fold (mapProc' _ _ _ _)}
                             ∙ sym (ih α .assoc∣∣X {P = Fold (mapProc' _ _ _ _)})))))
   ... | nope = refl
 
@@ -150,7 +150,7 @@ module _ (ih : ▹ StructCong ProcPi-alg (mapProc _ _) _≡_) where
                     cong₂ parProc (mapProc-id _ _) refl
                     ∙ ih α .comm∣∣X {P = P}
                     ∙ sym (ih α .ν∣∣X)
-                    ∙ cong′ νProc (ih α .comm∣∣X {Q = Fold (mapProc' _ _ _ _)}
+                    ∙ congS νProc (ih α .comm∣∣X {Q = Fold (mapProc' _ _ _ _)}
                             ∙ sym (ih α .assoc∣∣X {P = Fold (mapProc' _ _ _ _)})))))
   ... | nope = refl
 
@@ -159,7 +159,7 @@ module _ (ih : ▹ StructCong ProcPi-alg (mapProc _ _) _≡_) where
     ≡ synch' (λ _ → parProc) (λ _ → νProc) aP (mapStep (λ m i R' α → parProc (mapProc n m (i .fst) Q) (R' α)) aR)
   synch'-assoc (a , P) Q (b , R) with canSynchL? a b
   ... | local r r' = cong η (StepPath refl refl (later-ext (λ α → ih α .assoc∣∣X {P = P α})))
-  ... | bound r = cong η (StepPath refl refl (later-ext (λ α → cong′ νProc (ih α .assoc∣∣X {P = P α}))))
+  ... | bound r = cong η (StepPath refl refl (later-ext (λ α → congS νProc (ih α .assoc∣∣X {P = P α}))))
   ... | nope = refl
 
   synch'-assoc' : ∀ {n} (aP : Step (\ n → ▹ Proc n) n) aQ aR →
@@ -206,12 +206,12 @@ module _ (ih : ▹ StructCong ProcPi-alg (mapProc _ _) _≡_) where
         cong (bind R) (funExt (λ aR' →
           cong₂ _∪_
             (synch'-assoc aP' Q aR')
-            (cong′ (λ (f : ▹ (∀ n → Proc n → Proc n → Proc n)) → synch' (λ α {n} → f α n) (λ _ → νProc) aR' (mapStep (λ m i P' α → parProc (P' α) (mapProc _ m (i .fst) Q)) aP'))
+            (congS (λ (f : ▹ (∀ n → Proc n → Proc n → Proc n)) → synch' (λ α {n} → f α n) (λ _ → νProc) aR' (mapStep (λ m i P' α → parProc (P' α) (mapProc _ m (i .fst) Q)) aP'))
               (later-ext (λ α → funExt (λ _ → funExt (λ p → (funExt (λ q → ih α .comm∣∣X {P = q}))))))
-             ∙ cong′ (synch' (λ _ → parProc) (λ _ → νProc) aR') (StepPath refl refl (later-ext (λ α → ih α .comm∣∣X {P = theX aP' α})))
+             ∙ congS (synch' (λ _ → parProc) (λ _ → νProc) aR') (StepPath refl refl (later-ext (λ α → ih α .comm∣∣X {P = theX aP' α})))
              ∙ sym (synch'-assoc aR' Q aP')
-             ∙ cong′ (λ x → synch' (λ _ → parProc) (λ _ → νProc) x aP') {y = mapStep (λ m i R' α → parProc (mapProc _ m (i .fst) Q) (R' α)) aR'} (StepPath refl refl (later-ext (λ α → ih α .comm∣∣X {P = theX aR' α})))
-             ∙ cong′ (λ (f : ▹ (∀ n → Proc n → Proc n → Proc n)) → synch' (λ α {n} → f α n) (λ _ → νProc) (mapStep (λ m i R' α → parProc (mapProc _ m (i .fst) Q) (R' α)) aR') aP')
+             ∙ congS (λ x → synch' (λ _ → parProc) (λ _ → νProc) x aP') {y = mapStep (λ m i R' α → parProc (mapProc _ m (i .fst) Q) (R' α)) aR'} (StepPath refl refl (later-ext (λ α → ih α .comm∣∣X {P = theX aR' α})))
+             ∙ congS (λ (f : ▹ (∀ n → Proc n → Proc n → Proc n)) → synch' (λ α {n} → f α n) (λ _ → νProc) (mapStep (λ m i R' α → parProc (mapProc _ m (i .fst) Q) (R' α)) aR') aP')
                 (later-ext (λ α → funExt (λ _ → funExt (λ p → (funExt (λ q → ih α .comm∣∣X {P = p})))))))))
         ∙ sym (bind-map R _ _)))
 
@@ -243,14 +243,14 @@ module _ (ih : ▹ StructCong ProcPi-alg (mapProc _ _) _≡_) where
 
   synchsynchF : ∀ {n} (P : F' n (\ _ → Proc)) Q R →
      synchF P (synchF Q R) ≡ ø
-  synchsynchF P Q R = cong′ (bind P) (funExt \ a' → bind-bind Q _ _ ∙ cong′ (bind Q) (funExt \ b' → bind-bind R _ _ ∙ cong′ (bind R)
+  synchsynchF P Q R = congS (bind P) (funExt \ a' → bind-bind Q _ _ ∙ congS (bind Q) (funExt \ b' → bind-bind R _ _ ∙ congS (bind R)
     (funExt \ c' → synchsynch b' c' a') ∙ bind-ø R) ∙ bind-ø Q) ∙ bind-ø P
 
   step-LL : ∀ {n} P Q R →
     stepL {n} (stepL P Q) R ≡ stepL P (parProc Q R)
   step-LL {n} P Q R =
     mapmapP∞ _ _ P
-    ∙ cong′ (λ f → mapP∞ f P) (funExt (λ { (a , P') →
+    ∙ congS (λ f → mapP∞ f P) (funExt (λ { (a , P') →
         StepPath refl refl (later-ext (λ α →  ih α .assoc∣∣X {P = P' α} ∙ cong₂ parProc refl (sym (par-map _ _ (labelInj a) Q R))))}))
 
   assoc-synchF : ∀ {n} (P : F' n (\ _ → Proc)) Q R →
@@ -259,19 +259,19 @@ module _ (ih : ▹ StructCong ProcPi-alg (mapProc _ _) _≡_) where
 
   assoc-par : ∀ {n} {P Q R : Proc n} → parProc (parProc P Q) R ≡ parProc P (parProc Q R)
   assoc-par {n}{P}{Q}{R} =
-   cong₂ parProc (cong′ (λ x → isPi-alg.parX (x n) P Q) (fix-eq ProcPi-algF)) refl
-   ∙ cong′ (λ x → isPi-alg.parX (x n) (isPi-alg.parX (fix-eq ProcPi-algF i1 n) P Q) R) (fix-eq ProcPi-algF)
+   cong₂ parProc (congS (λ x → isPi-alg.parX (x n) P Q) (fix-eq ProcPi-algF)) refl
+   ∙ congS (λ x → isPi-alg.parX (x n) (isPi-alg.parX (fix-eq ProcPi-algF i1 n) P Q) R) (fix-eq ProcPi-algF)
    ∙ cong Fold (sym (assoc _ _ _ ∙ assoc _ _ _ ∙ assoc _ _ _)
                 ∙ cong₂ _∪_
                     (step-LL (Unfold P) Q R
-                     ∙ cong′ (λ f → mapP∞ f (Unfold P)) (funExt (λ P' →
-                         StepPath refl refl (later-ext (λ α → cong₂ parProc refl (cong′ (mapProc _ _ _) (cong′ (λ x → isPi-alg.parX (x n) Q R) (fix-eq ProcPi-algF))))))))
+                     ∙ congS (λ f → mapP∞ f (Unfold P)) (funExt (λ P' →
+                         StepPath refl refl (later-ext (λ α → cong₂ parProc refl (congS (mapProc _ _ _) (congS (λ x → isPi-alg.parX (x n) Q R) (fix-eq ProcPi-algF))))))))
                     (cong₂ _∪_ (step-LR P (Unfold Q) R)
                       (comm _ _ ∙ sym (assoc _ _ _)
                        ∙ cong₂ _∪_
                            (sym (step-RR P Q (Unfold R)
-                            ∙ cong′ (λ f → mapP∞ f (Unfold R)) (funExt (λ R' →
-                             StepPath refl refl (later-ext (λ α → cong₂ parProc (cong′ (mapProc _ _ _) (cong′ (λ x → isPi-alg.parX (x n) P Q) (fix-eq ProcPi-algF))) refl))))))
+                            ∙ congS (λ f → mapP∞ f (Unfold R)) (funExt (λ R' →
+                             StepPath refl refl (later-ext (λ α → cong₂ parProc (congS (mapProc _ _ _) (congS (λ x → isPi-alg.parX (x n) P Q) (fix-eq ProcPi-algF))) refl))))))
                            (comm _ _
                             ∙ cong₂ _∪_
                                 (synchF-L (Unfold P) (Unfold Q) R ∙ sym (bind-comm _ (stepL (Unfold Q) R) (Unfold P)))
@@ -294,8 +294,8 @@ module _ (ih : ▹ StructCong ProcPi-alg (mapProc _ _) _≡_) where
                             ∙ cong₂ _∪_ refl (bind-comm _ (Unfold (isPi-alg.parX (fix-eq ProcPi-algF i1 n) Q R)) (Unfold P))))
                      ∙ assoc _ _ _ ∙ assoc _ _ _)
                 ∙ assoc _ _ _)
-   ∙ sym (cong′ (λ x → isPi-alg.parX (x n) P (isPi-alg.parX (fix-eq ProcPi-algF i1 n) Q R)) (fix-eq ProcPi-algF))
-   ∙ sym (cong₂ parProc refl (cong′ (λ x → isPi-alg.parX (x n) Q R) (fix-eq ProcPi-algF)))
+   ∙ sym (congS (λ x → isPi-alg.parX (x n) P (isPi-alg.parX (fix-eq ProcPi-algF i1 n) Q R)) (fix-eq ProcPi-algF))
+   ∙ sym (cong₂ parProc refl (congS (λ x → isPi-alg.parX (x n) Q R) (fix-eq ProcPi-algF)))
 
 -- The equation characterizing replication as iterated parallel composition.
 
@@ -303,19 +303,19 @@ module _ (ih : ▹ StructCong ProcPi-alg (mapProc _ _) _≡_) where
     → stepL (synchF (Unfold P) (Unfold P)) (!Proc P) ≡ synchF (Unfold P) (Unfold (!Proc P))
   synch-! P =
     sym (unit _)
-    ∙ cong₂ _∪_ refl (sym (cong′ (λ P' → stepL P' (!Proc P)) (synchsynchF (Unfold P) (Unfold P) (Unfold P))))
+    ∙ cong₂ _∪_ refl (sym (congS (λ P' → stepL P' (!Proc P)) (synchsynchF (Unfold P) (Unfold P) (Unfold P))))
     ∙ cong₂ _∪_ (synchF-L (Unfold P) (Unfold P) (!Proc P) ∙ bind-comm _ (Unfold P) (stepL (Unfold P) (!Proc P)))
                 (synchF-L (Unfold P) (synchF (Unfold P) (Unfold P)) (!Proc P) ∙ bind-comm _ (Unfold P) (stepL (synchF (Unfold P) (Unfold P)) (!Proc P)))
     ∙ bind-comm _ (stepL (Unfold P) (!Proc P) ∪ stepL (synchF (Unfold P) (Unfold P)) (!Proc P)) (Unfold P)
-    ∙ cong′ (synchF (Unfold P)) (cong Unfold (sym (!Proc-eq {_}{P})))
+    ∙ congS (synchF (Unfold P)) (cong Unfold (sym (!Proc-eq {_}{P})))
 
   stepR-! : ∀ {n} {P : Proc n} → stepR P (Unfold (!Proc P)) ≡ Unfold (!Proc P)
   stepR-! {_}{P} =
     cong₂ mapP∞ (funExt (λ aP' → StepPath refl refl (later-ext (λ α → ih α .comm∣∣X {P = Fold (mapProc' _ _ _ _)})))) (refl {x = Unfold (!Proc P)})
     ∙ cong₂ stepL (cong Unfold (!Proc-eq {_}{P})) refl
     ∙ cong₂ _∪_
-        (step-LL (Unfold P) (!Proc P) P ∙ cong′ (stepL' (Unfold P)) (later-ext (λ α → ih α .comm∣∣X {P = !Proc P} ∙ sym (ih α .replX {P = P}))))
-        (step-LL (synchF (Unfold P) (Unfold P)) (!Proc P) P ∙ cong′ (stepL' (synchF (Unfold P) (Unfold P))) (later-ext (λ α → ih α .comm∣∣X {P = !Proc P} ∙ sym (ih α .replX {P = P}))))
+        (step-LL (Unfold P) (!Proc P) P ∙ congS (stepL' (Unfold P)) (later-ext (λ α → ih α .comm∣∣X {P = !Proc P} ∙ sym (ih α .replX {P = P}))))
+        (step-LL (synchF (Unfold P) (Unfold P)) (!Proc P) P ∙ congS (stepL' (synchF (Unfold P) (Unfold P))) (later-ext (λ α → ih α .comm∣∣X {P = !Proc P} ∙ sym (ih α .replX {P = P}))))
     ∙ cong Unfold (sym (!Proc-eq {P = P}))
 
   repl-par : ∀ {n} {P : Proc n} → !Proc P ≡ parProc P (!Proc P)
@@ -333,7 +333,7 @@ module _ (ih : ▹ StructCong ProcPi-alg (mapProc _ _) _≡_) where
        ≡⟨ cong₂ _∪_ (comm _ _) refl ⟩
        (stepL (Unfold P) (!Proc P) ∪ stepR P (Unfold (!Proc P))) ∪ synchF (Unfold P) (Unfold (!Proc P))
        ∎)
-    ∙ cong′ (λ x → isPi-alg.parX (x _) P (isPi-alg.!X (fix-eq ProcPi-algF i0 _) P)) (sym (fix-eq ProcPi-algF))
+    ∙ congS (λ x → isPi-alg.parX (x _) P (isPi-alg.!X (fix-eq ProcPi-algF i0 _) P)) (sym (fix-eq ProcPi-algF))
 
 -- Restriction of the nil process.
   ν-end : ∀ {n} → νProc endProc ≡ endProc {n}
@@ -344,19 +344,19 @@ module _ (ih : ▹ StructCong ProcPi-alg (mapProc _ _) _≡_) where
   ν-stepL' : ∀ {n} aP Q → stepν (mapStep (λ m i P' α → parProc (P' α) (mapProc _ _ (i .fst) (mapProc _ _ ι Q))) aP) ≡ stepL {n} (stepν aP) Q
   ν-stepL' (a , P) Q with canNu? a
   ν-stepL' (.(out _ _) , P) Q | out x x₁ = cong η (StepPath refl refl (later-ext (λ α →
-      cong′ νProc (cong₂ parProc refl (mapProc-id _ _)) ∙ ih α .ν∣∣X ∙ cong₂ parProc refl (sym (mapProc-id _ _)))))
+      congS νProc (cong₂ parProc refl (mapProc-id _ _)) ∙ ih α .ν∣∣X ∙ cong₂ parProc refl (sym (mapProc-id _ _)))))
 
   ν-stepL' (.(out _ _) , P) Q | out2 x x₁ = cong η (StepPath refl refl (later-ext (λ α → cong₂ parProc refl (mapProc-id _ _))))
   ν-stepL' (.(inp _ _) , P) Q | inp x x₁ =
     cong η (StepPath refl refl (later-ext (λ α →
-      cong′ νProc (cong₂ parProc refl (mapProc-id _ _)) ∙ ih α .ν∣∣X ∙ cong₂ parProc refl (sym (mapProc-id _ _)))))
+      congS νProc (cong₂ parProc refl (mapProc-id _ _)) ∙ ih α .ν∣∣X ∙ cong₂ parProc refl (sym (mapProc-id _ _)))))
   ν-stepL' (.(bout _) , P) Q | bout x =
     cong η (StepPath refl refl (later-ext (λ α →
       cong νProc (par-map _ _ (swap , swap-inj) _ _)
       ∙ cong νProc (cong₂ parProc refl
           (mapmapProc _ _ _ (_ , swap-inj) (_ , ι-inj) _
            ∙ mapmapProc _ _ _ (_ , \ x y p → ι-inj _ _ (swap-inj _ _ p)) (_ , ι-inj) _
-           ∙ cong′ (λ x → mapProc _ _ x Q) (funExt swap-ιι)
+           ∙ congS (λ x → mapProc _ _ x Q) (funExt swap-ιι)
            ∙ sym (mapmapProc _ _ _ (_ , ι-inj) (_ , ι-inj) _)))
       ∙ ih α .ν∣∣X)))
   ν-stepL' (.(binp _) , P) Q | binp x =
@@ -365,23 +365,23 @@ module _ (ih : ▹ StructCong ProcPi-alg (mapProc _ _) _≡_) where
       ∙ cong νProc (cong₂ parProc refl
           (mapmapProc _ _ _ (_ , swap-inj) (_ , ι-inj) _
            ∙ mapmapProc _ _ _ (_ , \ x y p → ι-inj _ _ (swap-inj _ _ p)) (_ , ι-inj) _
-           ∙ cong′ (λ x → mapProc _ _ x Q) (funExt swap-ιι)
+           ∙ congS (λ x → mapProc _ _ x Q) (funExt swap-ιι)
            ∙ sym (mapmapProc _ _ _ (_ , ι-inj) (_ , ι-inj) _)))
       ∙ ih α .ν∣∣X)))
   ν-stepL' (.τ , P) Q | τ = cong η (StepPath refl refl (later-ext (λ α →
-    cong′ νProc (cong₂ parProc refl (mapProc-id _ _)) ∙ ih α .ν∣∣X ∙ cong₂ parProc refl (sym (mapProc-id _ _)))))
+    congS νProc (cong₂ parProc refl (mapProc-id _ _)) ∙ ih α .ν∣∣X ∙ cong₂ parProc refl (sym (mapProc-id _ _)))))
   ν-stepL' (a , P) Q | nope x = refl
 
   ν-stepL : ∀ {m P Q} →
     νProc (Fold (stepL (Unfold P) (mapProc m _ ι Q)))
     ≡ Fold (stepL (Unfold (νProc P)) Q)
   ν-stepL {n}{P}{Q} =
-    cong′ (λ x → isPi-alg.νX (x _) (Fold (stepL (Unfold P) (mapProc n _ ι Q)))) (fix-eq ProcPi-algF)
+    congS (λ x → isPi-alg.νX (x _) (Fold (stepL (Unfold P) (mapProc n _ ι Q)))) (fix-eq ProcPi-algF)
     ∙ cong Fold
         (bind-map (Unfold P) _ _
          ∙ cong (bind (Unfold P)) (funExt (λ aP' → ν-stepL' aP' Q))
          ∙ sym (map-bind (Unfold P) _ _))
-    ∙ cong′ (λ x → Fold (stepL (Unfold (isPi-alg.νX (x _) P)) Q)) (sym (fix-eq ProcPi-algF))
+    ∙ congS (λ x → Fold (stepL (Unfold (isPi-alg.νX (x _) P)) Q)) (sym (fix-eq ProcPi-algF))
 
   ν-stepR' : ∀ {n} P aQ →
     bind (mapSProc n _ ι aQ) (λ v → stepν (mapStep (λ m i x α → parProc (mapProc _ _ (fst i) P) (x α)) v))
@@ -394,8 +394,8 @@ module _ (ih : ▹ StructCong ProcPi-alg (mapProc _ _) _≡_) where
   ν-stepR' P (`bout ch Q) with decName (ι ch) (fresh _)
   ν-stepR' P (`bout ch Q) | yes p = ⊥-rec (fresh-ι p)
   ν-stepR' P (`bout ch Q) | no p =
-    cong η (StepPath refl (cong′ bout (down-ι p))
-      (later-ext (λ α → cong′ νProc (par-map _ _ (_ , swap-inj) _ _
+    cong η (StepPath refl (congS bout (down-ι p))
+      (later-ext (λ α → congS νProc (par-map _ _ (_ , swap-inj) _ _
                                   ∙ cong₂ parProc (mapmapProc _ _ _ (_ , swap-inj) (_ , ι-inj) _ ∙ cong₂ (mapProc _ _) (funExt swap-ι-lift) refl)
                                                (mapmapProc _ _ _ (_ , swap-inj) (_ , lift-inj (_ , ι-inj)) _ ∙ cong₂ (mapProc _ _) (funExt swap-lift-ι) refl))
                          ∙ ih α .ν∣∣X
@@ -404,13 +404,13 @@ module _ (ih : ▹ StructCong ProcPi-alg (mapProc _ _) _≡_) where
   ν-stepR' P (`inp ch v Q) | yes p | _ = ⊥-rec (fresh-ι p)
   ν-stepR' P (`inp ch v Q) | no p | yes q = ⊥-rec (fresh-ι q)
   ν-stepR' P (`inp ch v Q) | no p | no q =
-    cong η (StepPath refl (λ i → inp (down-ι p i) (down-ι q i)) (later-ext (λ α → ih α .ν∣∣X ∙ cong₂ parProc (cong′ νProc (mapProc-id _ _) ∙ sym (mapProc-id _ _)) refl)))
+    cong η (StepPath refl (λ i → inp (down-ι p i) (down-ι q i)) (later-ext (λ α → ih α .ν∣∣X ∙ cong₂ parProc (congS νProc (mapProc-id _ _) ∙ sym (mapProc-id _ _)) refl)))
   ν-stepR' P (`binp ch Q) with decName (ι ch) (fresh _)
   ν-stepR' P (`binp ch Q) | yes p = ⊥-rec (fresh-ι p)
   ν-stepR' {n} P (`binp ch Q) | no p =
     cong₂ _∪_
-      (cong η (StepPath refl (cong′ binp (down-ι p))
-        (later-ext (λ α → cong′ νProc (par-map _ _ (_ , swap-inj) _ _
+      (cong η (StepPath refl (congS binp (down-ι p))
+        (later-ext (λ α → congS νProc (par-map _ _ (_ , swap-inj) _ _
                                     ∙ cong₂ parProc (mapmapProc _ _ _ (_ , swap-inj) (_ , ι-inj) _ ∙ cong₂ (mapProc _ _) (funExt swap-ι-lift) refl)
                                                  (mapmapProc _ _ _ (_ , swap-inj) (_ , lift-inj (_ , ι-inj)) _ ∙ cong₂ (mapProc _ _) (funExt swap-lift-ι) refl))
                            ∙ ih α .ν∣∣X
@@ -423,12 +423,12 @@ module _ (ih : ▹ StructCong ProcPi-alg (mapProc _ _) _≡_) where
       aux | inp x x₁ = ⊥-rec (fresh-ι (sym x₁))
       aux | nope x = refl
   ν-stepR' P (`τ Q) =
-    cong η (cong′ `τ (later-ext (λ α → ih α .ν∣∣X ∙ cong₂ parProc (cong νProc (mapProc-id _ _) ∙ sym (mapProc-id _ _)) refl)))
+    cong η (congS `τ (later-ext (λ α → ih α .ν∣∣X ∙ cong₂ parProc (cong νProc (mapProc-id _ _) ∙ sym (mapProc-id _ _)) refl)))
 
   ν-stepR : ∀ {m P Q} → νProc (Fold (stepR P (Unfold (mapProc m _ ι Q)))) ≡ Fold (stepR (νProc P) (Unfold Q))
   ν-stepR {m} {P} {Q} =
-    cong′ νProc (cong′ Fold (cong′ (stepR P) (mapProc'-eq' _ _ _ _)))
-    ∙ cong′ (λ x → isPi-alg.νX (x _) (Fold (stepR P (mapProcF (next mapProc') m (suc m) ι (Unfold Q))))) (fix-eq ProcPi-algF)
+    congS νProc (congS Fold (congS (stepR P) (mapProc'-eq' _ _ _ _)))
+    ∙ congS (λ x → isPi-alg.νX (x _) (Fold (stepR P (mapProcF (next mapProc') m (suc m) ι (Unfold Q))))) (fix-eq ProcPi-algF)
     ∙ cong Fold (bind-map (mapProcF (next mapProc') m (suc m) ι (Unfold Q)) _ _
                  ∙ bind-bind (Unfold Q) _ _
                  ∙ cong (bind (Unfold Q)) (funExt (ν-stepR' P))
@@ -479,7 +479,7 @@ module _ (ih : ▹ StructCong ProcPi-alg (mapProc _ _) _≡_) where
     = comm _ _ ∙ unit _
     ∙ sym (bind-bind (inps' (λ _ → mapProc') ι ch' Q) (synch' (λ _ → parProc)  (λ _ → νProc)(`out ch z P)) stepν)
     ∙ (cong₂ bind (cong₂ bind (inps-ι ch' Q) refl) refl ∙ cong₂ bind (synch'-out-inp (λ _ → parProc) (λ _ → νProc) P _ (r ∙ cong ι p) r') refl)
-    ∙ cong′ η (cong′ `τ (later-ext \ α → cong′ νProc (cong₂ parProc refl (cong₂ (mapProc _ _) (funExt snoc-ι-fresh) refl ∙ mapProc-id _ (Q _)))))
+    ∙ congS η (congS `τ (later-ext \ α → congS νProc (cong₂ parProc refl (cong₂ (mapProc _ _) (funExt snoc-ι-fresh) refl ∙ mapProc-id _ (Q _)))))
   ν-synch' (`out ch z P) (`binp ch' Q) | out2 {ch = dch} r r' | no ¬p
     = comm _ _ ∙ unit _ ∙ sym (bind-bind (inps' (λ _ → mapProc') ι ch' Q) (synch' (λ _ → parProc) (λ _ → νProc) (`out ch z P)) stepν)
     ∙ cong₂ bind (no-out P Q \ p _ → ¬p (ι-inj _ _ (sym r ∙ p))) refl
@@ -490,10 +490,10 @@ module _ (ih : ▹ StructCong ProcPi-alg (mapProc _ _) _≡_) where
   ν-synch' (`bout ch P) (`binp ch' Q) with canNu? (bout ch) | decName ch (ι ch')
   ν-synch' (`bout ch P) (`binp ch' Q) | bout {_} {dch} r | yes p with decName dch ch'
   ν-synch' (`bout _ P) (`binp ch' Q) | bout {_} {dch} r | yes p | yes p₁
-    = cong₂ _∪_ (cong′ η (cong′ `τ (later-ext \ α → (ih α .swapνX ∙ cong′ νProc (cong′ νProc (par-map _ _ (swap , swap-inj) (P α) _ ∙ cong₂ parProc refl
+    = cong₂ _∪_ (congS η (congS `τ (later-ext \ α → (ih α .swapνX ∙ congS νProc (congS νProc (par-map _ _ (swap , swap-inj) (P α) _ ∙ cong₂ parProc refl
                        (mapmapProc _ _ _ (_ , swap-inj) (_ , lift-inj (_ , ι-inj)) (Q α)
                         ∙ λ i → mapProc _ _ (funExt swap-lift-ι i) (Q α))))) 
-         ∙ cong′ νProc (ih α .ν∣∣X {P = Fold (mapProc' _ _ _ _)}))))
+         ∙ congS νProc (ih α .ν∣∣X {P = Fold (mapProc' _ _ _ _)}))))
                 (sym (bind-bind (inps' (λ _ → mapProc') ι ch' Q) _ _)
                  ∙ cong₂ bind (no-bout P Q) refl)
     ∙ unit _
@@ -547,7 +547,7 @@ module _ (ih : ▹ StructCong ProcPi-alg (mapProc _ _) _≡_) where
     with decName ch ch' | decName z z'
   ... | no ¬p | _ = cong₂ bind (no-synch'-out-inp _ _ _ _ \ p _ → ¬p (ι-inj _ _ (p ∙ r))) refl
   ... | yes p | no ¬r = cong₂ bind (no-synch'-out-inp _ _ _ _ \ _ r → ¬r (ι-inj _ _ (r ∙ r'))) refl
-  ... | yes p | yes p' = cong₂ bind (synch'-out-inp _ _ _ _ (cong ι p ∙ sym r) (cong ι p' ∙ sym r')) refl ∙ cong′ η (cong′ `τ (later-ext \ α → ih α .ν∣∣X)) 
+  ... | yes p | yes p' = cong₂ bind (synch'-out-inp _ _ _ _ (cong ι p ∙ sym r) (cong ι p' ∙ sym r')) refl ∙ congS η (congS `τ (later-ext \ α → ih α .ν∣∣X)) 
   ν-synch'2 (.(bout _) , P) (`out ch z Q) | bout r = refl
   ν-synch'2 (.(binp _) , P) (`out ch z Q) | binp {_} {ch'} r = refl
   ν-synch'2 (.τ , P) (`out ch z Q) | τ = refl
@@ -564,7 +564,7 @@ module _ (ih : ▹ StructCong ProcPi-alg (mapProc _ _) _≡_) where
   ν-synch'2 (.(binp _) , P) (`bout ch Q) | binp {_} {ch'} r with decName ch ch'
   ... | yes eq = 
     cong₂ bind (synch'-bout-binp _ _ _ P (cong ι eq ∙ sym r)) refl
-    ∙ cong′ η (cong′ `τ (later-ext \ α →
+    ∙ congS η (congS `τ (later-ext \ α →
         ih α .swapνX
         ∙ cong νProc (cong νProc (par-map _ _ (_ , swap-inj) _ _
                             ∙ cong₂ parProc refl
@@ -583,7 +583,7 @@ module _ (ih : ▹ StructCong ProcPi-alg (mapProc _ _) _≡_) where
     → νProc (Fold (synchF (Unfold P) (Unfold (mapProc m _ ι Q)))) ≡
          Fold (synchF (Unfold (νProc P)) (Unfold Q))
   ν-synchF {n} P Q =
-    cong′ (λ x → isPi-alg.νX (x _) (Fold (synchF (Unfold P) (Unfold (mapProc _ _ ι Q))))) (fix-eq ProcPi-algF)
+    congS (λ x → isPi-alg.νX (x _) (Fold (synchF (Unfold P) (Unfold (mapProc _ _ ι Q))))) (fix-eq ProcPi-algF)
     ∙ cong Fold
         (bind-bind (Unfold P) _ _
          ∙ cong (bind (Unfold P)) (funExt (λ aP' →
@@ -599,18 +599,18 @@ module _ (ih : ▹ StructCong ProcPi-alg (mapProc _ _) _≡_) where
                  ∙ sym (bind-∪ _ _ (stepν aP'))))
              ∙ bind-comm _ (Unfold Q) (stepν aP')))
          ∙ sym (bind-bind (Unfold P) _ _))
-    ∙ cong′ (λ x → Fold (synchF (Unfold (isPi-alg.νX (x _) P)) (Unfold Q))) (sym (fix-eq ProcPi-algF))
+    ∙ congS (λ x → Fold (synchF (Unfold (isPi-alg.νX (x _) P)) (Unfold Q))) (sym (fix-eq ProcPi-algF))
 
   ν-par : ∀ {m P Q} → νProc (parProc P (mapProc m _ ι Q)) ≡ parProc (νProc P) Q
   ν-par {n}{P}{Q} =
-    cong′ νProc (cong′ (λ x → isPi-alg.parX (x _) P (mapProc n _ ι Q)) (fix-eq ProcPi-algF))
-    ∙ cong′ (λ x → isPi-alg.νX (x _) (isPi-alg.parX (fix-eq ProcPi-algF i1 _) P (mapProc n _ ι Q))) (fix-eq ProcPi-algF)
+    congS νProc (congS (λ x → isPi-alg.parX (x _) P (mapProc n _ ι Q)) (fix-eq ProcPi-algF))
+    ∙ congS (λ x → isPi-alg.νX (x _) (isPi-alg.parX (fix-eq ProcPi-algF i1 _) P (mapProc n _ ι Q))) (fix-eq ProcPi-algF)
     ∙ cong Fold
         (cong₂ _∪_ (cong₂ _∪_
-                      (cong Unfold (cong′ (λ x → isPi-alg.νX (x _) (Fold (stepL (Unfold P) (mapProc n _ ι Q)))) (sym (fix-eq ProcPi-algF)) ∙ ν-stepL {P = P}))
-                      (cong Unfold (cong′ (λ x → isPi-alg.νX (x _) (Fold (stepR P (Unfold (mapProc n _ ι Q))))) (sym (fix-eq ProcPi-algF)) ∙ ν-stepR)))
-                   (cong Unfold (cong′ (λ x → isPi-alg.νX (x _) (Fold (synchF (Unfold P) (Unfold (mapProc _ _ ι Q))))) (sym (fix-eq ProcPi-algF)) ∙ ν-synchF P Q)))
-    ∙ cong′ (λ x → isPi-alg.parX (x n) (νProc P) Q) (sym (fix-eq ProcPi-algF))
+                      (cong Unfold (congS (λ x → isPi-alg.νX (x _) (Fold (stepL (Unfold P) (mapProc n _ ι Q)))) (sym (fix-eq ProcPi-algF)) ∙ ν-stepL {P = P}))
+                      (cong Unfold (congS (λ x → isPi-alg.νX (x _) (Fold (stepR P (Unfold (mapProc n _ ι Q))))) (sym (fix-eq ProcPi-algF)) ∙ ν-stepR)))
+                   (cong Unfold (congS (λ x → isPi-alg.νX (x _) (Fold (synchF (Unfold P) (Unfold (mapProc _ _ ι Q))))) (sym (fix-eq ProcPi-algF)) ∙ ν-synchF P Q)))
+    ∙ congS (λ x → isPi-alg.parX (x n) (νProc P) Q) (sym (fix-eq ProcPi-algF))
 
 -- The equation stating that the order in which a process is
 -- restricted twice does not matter (again with some extra lemmata).
@@ -631,107 +631,107 @@ module _ (ih : ▹ StructCong ProcPi-alg (mapProc _ _) _≡_) where
        (sym r')
     where
       r : stepν (mapSProc' _ _ swap (`out (fresh _) z P)) ≡ _
-      r = cong′ stepν (StepPath refl (cong₂ out (snoc-fresh _ _) (sym q)) refl) ∙ stepν-out-fresh
+      r = congS stepν (StepPath refl (cong₂ out (snoc-fresh _ _) (sym q)) refl) ∙ stepν-out-fresh
   ... | no ¬q =
     J (λ ch eq → ø ≡ bind (stepν (out (swap ch) (swap z) , (λ α → Fold (mapProc' _ _ swap (Unfold (P α)))))) stepν)
-      (sym (cong′ stepνF r ∙ no-stepν (out refl)))
+      (sym (congS stepνF r ∙ no-stepν (out refl)))
       (sym r')
     where
      r : stepν (mapSProc' _ _ swap (`out (fresh _) z P)) ≡ _
-     r = cong′ stepν (StepPath refl ((λ i → out (snoc-fresh (snoc (λ x → ι (ι x)) (fresh (suc n))) (ι (fresh n)) i) (sym (ι-down \ eq → ¬q (sym eq)) i)))
+     r = congS stepν (StepPath refl ((λ i → out (snoc-fresh (snoc (λ x → ι (ι x)) (fresh (suc n))) (ι (fresh n)) i) (sym (ι-down \ eq → ¬q (sym eq)) i)))
        refl) ∙ stepν-out (fresh _) _ (λ α → Fold (mapProc' _ _ swap (Unfold (P α))))
   stepν-swap {n} (`out ch z P) | out {ch = ch'}{z'} p q with canNu? (out ch' z')
   ... | out {ch = ch₁}{z₁} r r' =
-    sym (cong′ stepνF s ∙ stepν-out _ _ _ ∙ cong′ η (StepPath refl refl (later-ext (\ α → sym (ih α .swapνX)))))
-    ∙ λ i → bind (stepν (out (swap (sym (p ∙ cong′ ι r) i)) (swap (sym (q ∙ cong′ ι r') i)) , λ α → Fold (mapProc' _ _ swap (Unfold (P α))))) stepν
+    sym (congS stepνF s ∙ stepν-out _ _ _ ∙ congS η (StepPath refl refl (later-ext (\ α → sym (ih α .swapνX)))))
+    ∙ λ i → bind (stepν (out (swap (sym (p ∙ congS ι r) i)) (swap (sym (q ∙ congS ι r') i)) , λ α → Fold (mapProc' _ _ swap (Unfold (P α))))) stepν
     where
      s : stepν (mapSProc' _ _ swap (out _ _ , P)) ≡ _
-     s = cong′ stepν (StepPath refl (λ i → out (swap-ιι ch₁ i) (swap-ιι z₁ i)) refl) ∙ stepν-out _ _ _
+     s = congS stepν (StepPath refl (λ i → out (swap-ιι ch₁ i) (swap-ιι z₁ i)) refl) ∙ stepν-out _ _ _
   ... | out2 {ch = ch₁} r r' =
-   (cong′ η (StepPath refl refl
+   (congS η (StepPath refl refl
              (later-ext (\ α → cong νProc (sym (mapmapProc _ _ _ (_ , swap-inj) (_ , swap-inj) (P α) ∙ cong₂ (mapProc _ _) (funExt swapswap) refl ∙ mapProc-id _ _)))))
-     ∙ sym (cong′ stepνF s ∙ stepν-bout))
-     ∙ λ i → bind (stepν (out (swap (sym (p ∙ cong′ ι r) i)) (swap (sym (q ∙ cong′ ι r') i)) , λ α → Fold (mapProc' _ _ swap (Unfold (P α))))) stepν
+     ∙ sym (congS stepνF s ∙ stepν-bout))
+     ∙ λ i → bind (stepν (out (swap (sym (p ∙ congS ι r) i)) (swap (sym (q ∙ congS ι r') i)) , λ α → Fold (mapProc' _ _ swap (Unfold (P α))))) stepν
     where
       s : stepν (mapSProc' _ _ swap (out _ _ , P)) ≡ _
-      s = cong′ stepν (StepPath refl (cong′ (out (swap (ι (ι ch₁)))) (snoc-ι _ _ _ ∙ snoc-fresh _ _) ∙ λ i → out (swap-ιι ch₁ i) (fresh (suc n))) refl) ∙ stepν-out-fresh
+      s = congS stepν (StepPath refl (congS (out (swap (ι (ι ch₁)))) (snoc-ι _ _ _ ∙ snoc-fresh _ _) ∙ λ i → out (swap-ιι ch₁ i) (fresh (suc n))) refl) ∙ stepν-out-fresh
   ... | nope (out r) =
-    sym (cong′ stepνF s)
-    ∙ λ i → bind (stepν (out (swap (sym (p ∙ cong′ ι r) i)) (swap (q (~ i))) , λ α → Fold (mapProc' _ _ swap (Unfold (P α))))) stepν
+    sym (congS stepνF s)
+    ∙ λ i → bind (stepν (out (swap (sym (p ∙ congS ι r) i)) (swap (q (~ i))) , λ α → Fold (mapProc' _ _ swap (Unfold (P α))))) stepν
     where
       s : stepν (mapSProc' _ _ swap (out _ _ , P)) ≡ _
-      s = cong′ stepν (StepPath refl (cong′ (λ a → out a (swap (ι z'))) (snoc-ι _ _ _ ∙ snoc-fresh _ _)) refl) ∙ no-stepν (out refl)
+      s = congS stepν (StepPath refl (congS (λ a → out a (swap (ι z'))) (snoc-ι _ _ _ ∙ snoc-fresh _ _)) refl) ∙ no-stepν (out refl)
   stepν-swap (`out ch z P) | out2 {ch = ch'} p q with canNu? (bout ch')
   ... | bout {ch = ch₁} r =
-    sym (cong′ stepνF s ∙ stepν-out-fresh)
-    ∙ λ i → bind (stepν (out (swap (sym (p ∙ cong′ ι r) i)) (swap (q (~ i))) , λ α → Fold (mapProc' _ _ swap (Unfold (P α))))) stepν    
+    sym (congS stepνF s ∙ stepν-out-fresh)
+    ∙ λ i → bind (stepν (out (swap (sym (p ∙ congS ι r) i)) (swap (q (~ i))) , λ α → Fold (mapProc' _ _ swap (Unfold (P α))))) stepν    
     where
       s : stepν (mapSProc' _ _ swap (out _ _ , P)) ≡ _
-      s = cong′ stepν (StepPath refl (cong′ (out (swap (ι (ι ch₁)))) (snoc-fresh _ _) ∙ cong′ (λ a → out a (ι (fresh _))) (swap-ιι ch₁)) refl) ∙ stepν-out _ _ _
+      s = congS stepν (StepPath refl (congS (out (swap (ι (ι ch₁)))) (snoc-fresh _ _) ∙ congS (λ a → out a (ι (fresh _))) (swap-ιι ch₁)) refl) ∙ stepν-out _ _ _
   ... | nope (bout r) = 
-    sym (cong′ stepνF s)
-    ∙ λ i → bind (stepν (out (swap (sym (p ∙ cong′ ι r) i)) (swap (q (~ i))) , λ α → Fold (mapProc' _ _ swap (Unfold (P α))))) stepν    
+    sym (congS stepνF s)
+    ∙ λ i → bind (stepν (out (swap (sym (p ∙ congS ι r) i)) (swap (q (~ i))) , λ α → Fold (mapProc' _ _ swap (Unfold (P α))))) stepν    
     where
       s : stepν (mapSProc' _ _ swap (out _ _ , P)) ≡ _
-      s = cong′ stepν (StepPath refl (cong′ (out (swap (ι (fresh _)))) (snoc-fresh _ _) ∙ cong′ (λ a → out a (ι (fresh _))) (snoc-ι _ _ _ ∙ snoc-fresh _ _)) refl) ∙ no-stepν (out refl)  
+      s = congS stepν (StepPath refl (congS (out (swap (ι (fresh _)))) (snoc-fresh _ _) ∙ congS (λ a → out a (ι (fresh _))) (snoc-ι _ _ _ ∙ snoc-fresh _ _)) refl) ∙ no-stepν (out refl)  
   stepν-swap (bout ch0 , P) with canNu? (bout ch0)
   stepν-swap (`bout ch0 P) | bout {ch = ch} p with canNu? (bout ch)
   ... | bout {ch = ch'} q =
-    sym (cong stepνF r ∙ stepν-bout ∙ cong′ η (StepPath refl refl (later-ext \ α →
-    cong νProc (ν-map _ _ (_ , swap-inj) _ ∙ cong′ νProc (mapmapProc _ _ _ (_ , lift-inj (_ , swap-inj)) (_ , swap-inj) _
+    sym (cong stepνF r ∙ stepν-bout ∙ congS η (StepPath refl refl (later-ext \ α →
+    cong νProc (ν-map _ _ (_ , swap-inj) _ ∙ congS νProc (mapmapProc _ _ _ (_ , lift-inj (_ , swap-inj)) (_ , swap-inj) _
                                                    ∙ mapmapProc _ _ _ lift-swap-Inj (_ , lift-inj (_ , swap-inj)) _
       ∙ cong₂ (mapProc _ _) (funExt lift-vs-swap) refl ∙ sym (mapmapProc _ _ _ (swap , swap-inj) lift-swap-Inj (P α)) ))
       ∙ sym (ih α .swapνX) ∙ sym (cong νProc (ν-map _ _ (_ , swap-inj) _ ∙ cong νProc (mapmapProc _ _ _ (_ , lift-inj (_ , swap-inj)) (_ , swap-inj) (P α)))))))
-    ∙ λ i → bind (stepν (bout (swap (sym (p ∙ cong′ ι q) i)) , λ α → Fold (mapProc' _ _ (lift swap) (Unfold (P α))))) stepν    
+    ∙ λ i → bind (stepν (bout (swap (sym (p ∙ congS ι q) i)) , λ α → Fold (mapProc' _ _ (lift swap) (Unfold (P α))))) stepν    
     where
       r : stepν (mapSProc' _ _ swap (bout _ , P)) ≡ _
-      r = cong′ stepν (StepPath refl (cong′ bout (swap-ιι ch')) refl) ∙ stepν-bout
+      r = congS stepν (StepPath refl (congS bout (swap-ιι ch')) refl) ∙ stepν-bout
   ... | nope (bout q) =
     sym (cong stepνF r)
-    ∙ λ i → bind (stepν (bout (swap (sym (p ∙ cong′ ι q) i)) , λ α → Fold (mapProc' _ _ (lift swap) (Unfold (P α))))) stepν    
+    ∙ λ i → bind (stepν (bout (swap (sym (p ∙ congS ι q) i)) , λ α → Fold (mapProc' _ _ (lift swap) (Unfold (P α))))) stepν    
     where
       r : stepν (mapSProc' _ _ swap (bout _ , P)) ≡ _
-      r = cong′ stepν (StepPath refl (cong′ bout (snoc-ι _ _ _ ∙ snoc-fresh _ _)) refl) ∙ no-stepν (bout refl)  
+      r = congS stepν (StepPath refl (congS bout (snoc-ι _ _ _ ∙ snoc-fresh _ _)) refl) ∙ no-stepν (bout refl)  
   stepν-swap (`bout ch0 P) | nope (bout p) =
     sym (cong stepνF r ∙ no-stepν (bout refl))
     ∙ λ i → bind (stepν (bout (swap (p (~ i))) , λ α → Fold (mapProc' _ _ (lift swap) (Unfold (P α))))) stepν    
     where
      r : stepν (mapSProc' _ _ swap (bout _ , P)) ≡ _
-     r = cong′ stepν (StepPath refl (cong′ bout (snoc-fresh _ _)) refl) ∙ stepν-bout
+     r = congS stepν (StepPath refl (congS bout (snoc-fresh _ _)) refl) ∙ stepν-bout
   stepν-swap (inp ch0 z0 , P) with canNu? (inp ch0 z0)
   ... | inp {ch = ch} {z} p q with canNu? (inp ch z)
   ... | nope (inp (_⊎_.inl s)) =
     sym (cong stepνF r)
-    ∙ λ i → bind (stepν (inp (swap (sym (p ∙ cong′ ι s) i)) (swap (q (~ i))) , λ α → Fold (mapProc' _ _ swap (Unfold (P α))))) stepν    
+    ∙ λ i → bind (stepν (inp (swap (sym (p ∙ congS ι s) i)) (swap (q (~ i))) , λ α → Fold (mapProc' _ _ swap (Unfold (P α))))) stepν    
     where
       r : stepν (mapSProc' _ _ swap (inp _ _ , P)) ≡ _
-      r = cong′ stepν (StepPath refl (cong′ (inp (swap (ι (fresh _)))) (snoc-ι _ _ _) ∙ cong′ (λ a → inp a (snoc (λ x → ι (ι x)) (fresh _) z)) (snoc-ι _ _ _ ∙ snoc-fresh _ _)) refl) ∙ no-stepν (inp (_⊎_.inl refl))
+      r = congS stepν (StepPath refl (congS (inp (swap (ι (fresh _)))) (snoc-ι _ _ _) ∙ congS (λ a → inp a (snoc (λ x → ι (ι x)) (fresh _) z)) (snoc-ι _ _ _ ∙ snoc-fresh _ _)) refl) ∙ no-stepν (inp (_⊎_.inl refl))
   ... | nope (inp (_⊎_.inr s)) =
     sym (cong stepνF r)
     ∙ λ i → bind (stepν (inp (swap (p (~ i))) (swap (sym (q ∙ cong ι s) i)) , λ α → Fold (mapProc' _ _ swap (Unfold (P α))))) stepν    
     where
       r : stepν (mapSProc' _ _ swap (inp _ _ , P)) ≡ _
-      r = cong′ stepν (StepPath refl (cong′ (inp (swap (ι ch))) (snoc-ι _ _ _ ∙ snoc-fresh _ _) ∙ cong′ (λ a → inp a _) (snoc-ι _ _ _)) refl) ∙ no-stepν (inp (_⊎_.inr refl))
+      r = congS stepν (StepPath refl (congS (inp (swap (ι ch))) (snoc-ι _ _ _ ∙ snoc-fresh _ _) ∙ congS (λ a → inp a _) (snoc-ι _ _ _)) refl) ∙ no-stepν (inp (_⊎_.inr refl))
   ... | inp {ch = ch₁}{z₁}s s' =
-    sym (cong stepνF r ∙ stepν-inp _ _ _ ∙ cong′ η (StepPath refl refl (later-ext \ α → sym (ih α .swapνX))))
+    sym (cong stepνF r ∙ stepν-inp _ _ _ ∙ congS η (StepPath refl refl (later-ext \ α → sym (ih α .swapνX))))
     ∙ λ i → bind (stepν (inp (swap (sym (p ∙ cong ι s) i)) (swap (sym (q ∙ cong ι s') i)) , λ α → Fold (mapProc' _ _ swap (Unfold (P α))))) stepν    
     where
       r : stepν (mapSProc' _ _ swap (inp _ _ , P)) ≡ _
-      r = cong′ stepν (StepPath refl (λ i → inp (swap-ιι ch₁ i) (swap-ιι z₁ i)) refl) ∙ stepν-inp _ _ _
+      r = congS stepν (StepPath refl (λ i → inp (swap-ιι ch₁ i) (swap-ιι z₁ i)) refl) ∙ stepν-inp _ _ _
   stepν-swap (inp ch0 z0 , P) | nope (inp (_⊎_.inl p)) with decName (fresh _) (swap z0)
   ... | yes q =
     sym (cong stepνF r)
     ∙ λ i → bind (stepν (inp (swap (sym p i)) (swap z0) , λ α → Fold (mapProc' _ _ swap (Unfold (P α))))) stepν    
     where
       r : stepν (mapSProc' _ _ swap (inp _ _ , P)) ≡ _
-      r = cong′ stepν (StepPath refl (cong′ (inp (swap (fresh _))) (sym q) ∙ cong′ (λ a → inp a (fresh _)) (snoc-fresh _ _)) refl) ∙ no-stepν (inp (_⊎_.inr refl))
+      r = congS stepν (StepPath refl (congS (inp (swap (fresh _))) (sym q) ∙ congS (λ a → inp a (fresh _)) (snoc-fresh _ _)) refl) ∙ no-stepν (inp (_⊎_.inr refl))
   ... | no ¬q =
     J (λ ch eq → ø ≡ bind (stepν (inp (swap ch) (swap z0) , (λ α → Fold (mapProc' _ _ swap (Unfold (P α)))))) stepν)
-      (sym (cong′ stepνF r ∙ no-stepν (inp (_⊎_.inl refl))))
+      (sym (congS stepνF r ∙ no-stepν (inp (_⊎_.inl refl))))
       (sym p)
     where
      r : stepν (mapSProc' _ _ swap (`inp (fresh _) z0 P)) ≡ _
-     r = cong′ stepν (StepPath refl ((λ i → inp (snoc-fresh (snoc (λ x → ι (ι x)) (fresh (suc _))) (ι (fresh _)) i) (sym (ι-down \ eq → ¬q (sym eq)) i)))
+     r = congS stepν (StepPath refl ((λ i → inp (snoc-fresh (snoc (λ x → ι (ι x)) (fresh (suc _))) (ι (fresh _)) i) (sym (ι-down \ eq → ¬q (sym eq)) i)))
        refl) ∙ stepν-inp (fresh _) _ (λ α → Fold (mapProc' _ _ swap (Unfold (P α))))
   stepν-swap (inp ch0 z0 , P) | nope (inp (_⊎_.inr p)) with decName (fresh _) (swap ch0)
   ... | yes q =
@@ -739,40 +739,40 @@ module _ (ih : ▹ StructCong ProcPi-alg (mapProc _ _) _≡_) where
     ∙ λ i → bind (stepν (inp (swap ch0) (swap (sym p i)) , λ α → Fold (mapProc' _ _ swap (Unfold (P α))))) stepν        
     where
       r : stepν (mapSProc' _ _ swap (inp _ _ , P)) ≡ _
-      r = cong′ stepν (StepPath refl (cong′ (inp (swap ch0)) (snoc-fresh _ _) ∙ cong′ (λ a → inp a _) (sym q)) refl) ∙ no-stepν (inp (_⊎_.inl refl))
+      r = congS stepν (StepPath refl (congS (inp (swap ch0)) (snoc-fresh _ _) ∙ congS (λ a → inp a _) (sym q)) refl) ∙ no-stepν (inp (_⊎_.inl refl))
   ... | no ¬q = 
     J (λ z0 eq → ø ≡ bind (stepν (inp (swap ch0) (swap z0) , (λ α → Fold (mapProc' _ _ swap (Unfold (P α)))))) stepν)
-      (sym (cong′ stepνF r ∙ no-stepν (inp (_⊎_.inr refl))))
+      (sym (congS stepνF r ∙ no-stepν (inp (_⊎_.inr refl))))
       (sym p)
     where
      r : stepν (mapSProc' _ _ swap (`inp ch0 (fresh _) P)) ≡ _
-     r = cong′ stepν (StepPath refl ((λ i → inp (sym (ι-down \ eq → ¬q (sym eq)) i) (snoc-fresh (snoc (λ x → ι (ι x)) (fresh (suc _))) (ι (fresh _)) i)))
+     r = congS stepν (StepPath refl ((λ i → inp (sym (ι-down \ eq → ¬q (sym eq)) i) (snoc-fresh (snoc (λ x → ι (ι x)) (fresh (suc _))) (ι (fresh _)) i)))
        refl) ∙ stepν-inp _ (fresh _) (λ α → Fold (mapProc' _ _ swap (Unfold (P α))))
   stepν-swap (binp ch0 , P) with canNu? (binp ch0)
   ... | binp {ch = ch} p with canNu? (binp ch)
   ... | binp {_} {ch2} q =
-    sym (cong′ stepνF r ∙ stepν-binp ∙ cong′ η (StepPath refl refl (later-ext \ α →
+    sym (congS stepνF r ∙ stepν-binp ∙ congS η (StepPath refl refl (later-ext \ α →
       cong νProc (ν-map _ _ (_ , swap-inj) _ ∙ cong νProc (mapmapProc _ _ _ (_ ,  lift-inj (_ , swap-inj)) (_ , swap-inj) _ ∙ mapmapProc _ _ _ lift-swap-Inj (_ , lift-inj (_ , swap-inj)) _
        ∙ cong₂ (mapProc _ _) (funExt lift-vs-swap) refl ∙ sym (mapmapProc _ _ _ (swap , swap-inj) lift-swap-Inj (P α)) ))
        ∙ sym (ih α .swapνX) ∙ sym (cong νProc (ν-map _ _ (_ , swap-inj) _ ∙ cong νProc (mapmapProc _ _ _ (_ , lift-inj (_ , swap-inj)) (_ , swap-inj) (P α))))
     )))
-    ∙ λ i → bind (stepν (binp (swap (sym (p ∙ cong′ ι q) i)) , λ α → Fold (mapProc' _ _ (lift swap) (Unfold (P α))))) stepν    
+    ∙ λ i → bind (stepν (binp (swap (sym (p ∙ congS ι q) i)) , λ α → Fold (mapProc' _ _ (lift swap) (Unfold (P α))))) stepν    
     where
       r : stepν (mapSProc' _ _ swap (binp _ , P)) ≡ _
-      r = cong′ stepν (StepPath refl (cong′ binp (swap-ιι ch2)) refl) ∙ stepν-binp
+      r = congS stepν (StepPath refl (congS binp (swap-ιι ch2)) refl) ∙ stepν-binp
   ... | nope (binp q) =
-    sym (cong′ stepνF r)
-    ∙ λ i → bind (stepν (binp (swap (sym (p ∙ cong′ ι q) i)) , λ α → Fold (mapProc' _ _ (lift swap) (Unfold (P α))))) stepν    
+    sym (congS stepνF r)
+    ∙ λ i → bind (stepν (binp (swap (sym (p ∙ congS ι q) i)) , λ α → Fold (mapProc' _ _ (lift swap) (Unfold (P α))))) stepν    
     where
       r : stepν (mapSProc' _ _ swap (binp _ , P)) ≡ _
-      r = cong′ stepν (StepPath refl (cong′ binp (snoc-ι _ _ _ ∙ snoc-fresh _ _)) refl) ∙ no-stepν (binp refl)
+      r = congS stepν (StepPath refl (congS binp (snoc-ι _ _ _ ∙ snoc-fresh _ _)) refl) ∙ no-stepν (binp refl)
   stepν-swap (binp ch0 , P) | nope (binp p) =
-    sym (cong′ stepνF r ∙ no-stepν (binp refl))
+    sym (congS stepνF r ∙ no-stepν (binp refl))
     ∙ λ i → bind (stepν (binp (swap (sym p i)) , λ α → Fold (mapProc' _ _ (lift swap) (Unfold (P α))))) stepν        
     where
       r : stepν (mapSProc' _ _ swap (binp _ , P)) ≡ _
-      r = cong′ stepν (StepPath refl (cong′ binp (snoc-fresh _ _)) refl) ∙ stepν-binp
-  stepν-swap (τ , P) = cong′ η (cong′ `τ (later-ext \ α → ih α .swapνX))
+      r = congS stepν (StepPath refl (congS binp (snoc-fresh _ _)) refl) ∙ stepν-binp
+  stepν-swap (τ , P) = congS η (congS `τ (later-ext \ α → ih α .swapνX))
   
   ν-swap : ∀ {n} {P : Proc (suc (suc n))} → νProc (νProc P) ≡ νProc (νProc (mapProc _ _ swap P))
   ν-swap {n} {P} =
@@ -781,7 +781,7 @@ module _ (ih : ▹ StructCong ProcPi-alg (mapProc _ _) _≡_) where
     Fold (bind (bind (Unfold P) stepν) stepν)
       ≡⟨ cong Fold (bind-bind (Unfold P) stepν stepν) ⟩
     Fold (bind (Unfold P) (λ x → bind (stepν x) stepν))
-      ≡⟨ cong Fold (cong′ (bind (Unfold P)) (funExt stepν-swap)) ⟩
+      ≡⟨ cong Fold (congS (bind (Unfold P)) (funExt stepν-swap)) ⟩
     Fold (bind (Unfold P) (λ x → bind (stepν (mapSProc' _ _ swap x)) stepν))
       ≡⟨ cong Fold (sym (bind-bind (Unfold P) _ _)) ⟩
     Fold (bind (bind (Unfold P) (λ x → stepν (mapSProc' _ _ swap x))) stepν)
@@ -806,12 +806,12 @@ module _ (ih : ▹ StructCong ProcPi-alg (mapProc _ _) _≡_) where
     { refl≈X = refl
     ; sym≈X = sym
     ; _∙≈X_ = _∙_
-    ; cong·X = λ {_}{_}{_}{_}{a} → cong′ (actProc a)
+    ; cong·X = λ {_}{_}{_}{_}{a} → congS (actProc a)
     ; cong⊕X = λ eq1 eq2 → cong₂ sumProc eq1 eq2
     ; cong∣∣X = λ eq1 eq2 → cong₂ parProc eq1 eq2
-    ; congνX = cong′ νProc
-    ; congguardX = cong′ (guardProc _ _)
-    ; cong!X = cong′ !Proc
+    ; congνX = congS νProc
+    ; congguardX = congS (guardProc _ _)
+    ; cong!X = congS !Proc
     ; unit⊕X = unit-sum
     ; comm⊕X = comm-sum
     ; assoc⊕X = assoc-sum

--- a/pi-calculus/semantics/StructuralCongruence.agda
+++ b/pi-calculus/semantics/StructuralCongruence.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --guarded #-}
+{-# OPTIONS --cubical --guarded -WnoUnsupportedIndexedMatch #-}
 
 open import Cubical.Data.Sum hiding (inl; inr) 
 open import Cubical.Data.Empty renaming (rec to ⊥-rec)

--- a/pi-calculus/semantics/StructuralCongruence.agda
+++ b/pi-calculus/semantics/StructuralCongruence.agda
@@ -210,7 +210,7 @@ module _ (ih : ▹ StructCong ProcPi-alg (mapProc _ _) _≡_) where
               (later-ext (λ α → funExt (λ _ → funExt (λ p → (funExt (λ q → ih α .comm∣∣X {P = q}))))))
              ∙ congS (synch' (λ _ → parProc) (λ _ → νProc) aR') (StepPath refl refl (later-ext (λ α → ih α .comm∣∣X {P = theX aP' α})))
              ∙ sym (synch'-assoc aR' Q aP')
-             ∙ congS (λ x → synch' (λ _ → parProc) (λ _ → νProc) x aP') {y = mapStep (λ m i R' α → parProc (mapProc _ m (i .fst) Q) (R' α)) aR'} (StepPath refl refl (later-ext (λ α → ih α .comm∣∣X {P = theX aR' α})))
+             ∙ congS {y = mapStep (λ m i R' α → parProc (mapProc _ m (i .fst) Q) (R' α)) aR'} (λ x → synch' (λ _ → parProc) (λ _ → νProc) x aP') (StepPath refl refl (later-ext (λ α → ih α .comm∣∣X {P = theX aR' α})))
              ∙ congS (λ (f : ▹ (∀ n → Proc n → Proc n → Proc n)) → synch' (λ α {n} → f α n) (λ _ → νProc) (mapStep (λ m i R' α → parProc (mapProc _ m (i .fst) Q) (R' α)) aR') aP')
                 (later-ext (λ α → funExt (λ _ → funExt (λ p → (funExt (λ q → ih α .comm∣∣X {P = p})))))))))
         ∙ sym (bind-map R _ _)))


### PR DESCRIPTION
I was trying to study the formalization and couldn't typecheck with my current version of Agda. I made some small changes to make it work.